### PR TITLE
Add directx debug layer exception to the list of exceptions to catch.

### DIFF
--- a/src/ctrl/ctrl.mdesk
+++ b/src/ctrl/ctrl.mdesk
@@ -43,6 +43,7 @@ CTRL_ExceptionCodeKindTable:
   {Win32ProcedureNotFound              win32_procedure_not_found                   0xc06d007f  0  "(Win32) Procedure Not Found"                                    }
   {Win32SanitizerErrorDetected         win32_sanitizer_error_detected              0xe073616e  1  "(Win32) Sanitizer Error Detected"                               }
   {Win32SanitizerRawAccessViolation    win32_sanitizer_raw_access_violation        0xe0736171  0  "(Win32) Sanitizer Raw Access Violation"                         }
+  {Win32DirectXDebugLayer              win32_directx_debug_layer                   0x0000087A  1  "(Win32) DirectX Debug Layer"                                    }
 }
 
 ////////////////////////////////

--- a/src/ctrl/generated/ctrl.meta.h
+++ b/src/ctrl/generated/ctrl.meta.h
@@ -45,6 +45,7 @@ CTRL_ExceptionCodeKind_Win32ModuleNotFound,
 CTRL_ExceptionCodeKind_Win32ProcedureNotFound,
 CTRL_ExceptionCodeKind_Win32SanitizerErrorDetected,
 CTRL_ExceptionCodeKind_Win32SanitizerRawAccessViolation,
+CTRL_ExceptionCodeKind_Win32DirectXDebugLayer,
 CTRL_ExceptionCodeKind_COUNT
 } CTRL_ExceptionCodeKind;
 
@@ -87,6 +88,7 @@ U32 ctrl_exception_code_kind_code_table[] =
 0xc06d007f,
 0xe073616e,
 0xe0736171,
+0x0000087A,
 };
 
 String8 ctrl_exception_code_kind_display_string_table[] =
@@ -128,6 +130,7 @@ str8_lit_comp("(Win32) Module Not Found"),
 str8_lit_comp("(Win32) Procedure Not Found"),
 str8_lit_comp("(Win32) Sanitizer Error Detected"),
 str8_lit_comp("(Win32) Sanitizer Raw Access Violation"),
+str8_lit_comp("(Win32) DirectX Debug Layer"),
 };
 
 String8 ctrl_exception_code_kind_lowercase_code_string_table[] =
@@ -169,6 +172,7 @@ str8_lit_comp("win32_module_not_found"),
 str8_lit_comp("win32_procedure_not_found"),
 str8_lit_comp("win32_sanitizer_error_detected"),
 str8_lit_comp("win32_sanitizer_raw_access_violation"),
+str8_lit_comp("win32_directx_debug_layer"),
 };
 
 B8 ctrl_exception_code_kind_default_enable_table[] =
@@ -210,6 +214,7 @@ B8 ctrl_exception_code_kind_default_enable_table[] =
 0,
 1,
 0,
+1,
 };
 
 


### PR DESCRIPTION
When enabling the directx debug layer it is possible to break on error.
To do this the debug layer sends an exception with code 0x0000087A, I added this exception raddebugger can catch.