### PR TITLE
Fix ALT overriding text input

### DIFF
--- a/src/df/gfx/df_views.c
+++ b/src/df/gfx/df_views.c
@@ -847,6 +847,15 @@ df_eval_watch_view_build(DF_Window *ws, DF_Panel *panel, DF_View *view, DF_EvalW
     }
   }
   
+  // check if edit is still live and focus is on the same panel
+  if(ui_is_focus_active())
+  {
+    ui_state->is_editing = ewv->input_editing;
+  }
+  else if(ewv->input_editing)
+  {
+    ui_state->is_editing = 0;
+  }
   //////////////////////////////
   //- rjf: build ui
   //
@@ -1565,6 +1574,7 @@ df_eval_watch_view_build(DF_Window *ws, DF_Panel *panel, DF_View *view, DF_EvalW
   if(edit_end)
   {
     ewv->input_editing = 0;
+    ui_state->is_editing = 0;
   }
   
   //////////////////////////////
@@ -2943,6 +2953,16 @@ DF_VIEW_UI_FUNCTION_DEF(Target)
       }
     }
   }
+
+  // check if edit is still live and focus is on the same panel
+  if(ui_is_focus_active())
+  {
+    ui_state->is_editing = tv->input_editing;
+  }
+  else if(tv->input_editing)
+  {
+    ui_state->is_editing = 0;
+  }
   
   //- rjf: build
   Rng1S64 visible_row_range = {0};
@@ -3113,6 +3133,7 @@ DF_VIEW_UI_FUNCTION_DEF(Target)
   if(edit_end)
   {
     tv->input_editing = 0;
+    ui_state->is_editing = 0;
   }
   if(edit_submit)
   {
@@ -3393,6 +3414,16 @@ DF_VIEW_UI_FUNCTION_DEF(FilePathMap)
       }
     }
   }
+
+  // check if edit is still live and focus is on the same panel
+  if(ui_is_focus_active())
+  {
+    ui_state->is_editing = fpms->input_editing;
+  }
+  else if(fpms->input_editing)
+  {
+    ui_state->is_editing = 0;
+  }
   
   //- rjf: build
   DF_Handle commit_map = df_handle_zero();
@@ -3603,6 +3634,7 @@ DF_VIEW_UI_FUNCTION_DEF(FilePathMap)
   if(edit_end)
   {
     fpms->input_editing = 0;
+    ui_state->is_editing = 0;
   }
   
   //- rjf: move down one row if submitted
@@ -4181,6 +4213,16 @@ DF_VIEW_UI_FUNCTION_DEF(Modules)
       edit_submit = 1;
     }
   }
+
+  // check if edit is still live and focus is on the same panel
+  if(ui_is_focus_active())
+  {
+    ui_state->is_editing = mv->txt_editing;
+  }
+  else if(mv->txt_editing)
+  {
+    ui_state->is_editing = 0;
+  }
   
   //- rjf: build table
   DF_Entity *commit_module = &df_g_nil_entity;
@@ -4338,6 +4380,7 @@ DF_VIEW_UI_FUNCTION_DEF(Modules)
   if(edit_end)
   {
     mv->txt_editing = 0;
+    ui_state->is_editing = 0;
   }
   
   //- rjf: selected num -> selected entity

--- a/src/raddbg/raddbg.c
+++ b/src/raddbg/raddbg.c
@@ -157,7 +157,21 @@ update_and_render(OS_Handle repaint_window_handle, void *user_data)
     {
       next = event->next;
       DF_Window *ws = df_window_from_os_handle(event->window);
-      if(ws == 0)
+      DF_CmdQueryRule query_rule = DF_CmdQueryRule_Null;
+      // check if focused panel has an active command query
+      {
+        DF_Panel *panel = ws->focused_panel;
+        if(!df_panel_is_nil(panel))
+        {
+          DF_View *view =  df_selected_view_from_panel(panel);
+          if(!df_view_is_nil(view))
+          {
+              query_rule = view->cmd_spec->info.query_rule;
+          }
+        }
+      }
+
+      if(ws == 0 || ui_state->is_editing || query_rule != DF_CmdQueryRule_Null)
       {
         continue;
       }

--- a/src/ui/ui_core.h
+++ b/src/ui/ui_core.h
@@ -401,6 +401,7 @@ struct UI_State
   Vec2F32 drag_start_mouse;
   Arena *drag_state_arena;
   String8 drag_state_data;
+  B32 is_editing;
   
   //- rjf: context menu state
   UI_Key ctx_menu_anchor_key;


### PR DESCRIPTION
Issue: https://github.com/EpicGames/raddebugger/issues/16

Set is_editing to true when an active panel begins an edit. If the panel focus goes somewhere else and the edit is still live in the background it should let you use ALT normally. This doesn't take commands into account so they need to be checked seperately.

One other check that I noticed was `ws->autocomp_last_frame_idx+1 >= df_frame_index()` but this would only work for name types, like expressions where you have the auto complete available. The check in the commit should work for all input types that are build in `DF_VIEW_UI_FUNCTION_DEF`.