### PR TITLE
copy from disassembly view

### DIFF
--- a/src/df/gfx/df_views.c
+++ b/src/df/gfx/df_views.c
@@ -6021,7 +6021,7 @@ DF_VIEW_UI_FUNCTION_DEF(Disassembly)
   B32 snap[Axis2_COUNT] = {0};
   if(!is_loading && is_focused && visible_line_num_range.max > visible_line_num_range.min)
   {
-    snap[Axis2_X] = snap[Axis2_Y] = df_do_dasm_controls(dasm_handle, ClampBot(visible_line_count, 10) - 10, &dv->cursor, &dv->mark, &dv->preferred_column);
+    snap[Axis2_X] = snap[Axis2_Y] = df_do_dasm_controls(dasm_handle, &code_slice_params, ClampBot(visible_line_count, 10) - 10, &dv->cursor, &dv->mark, &dv->preferred_column);
   }
   
   //////////////////////////////
@@ -6142,18 +6142,15 @@ DF_VIEW_UI_FUNCTION_DEF(Disassembly)
     //- rjf: copy text
     if(!txt_pt_match(sig.copy_range.min, sig.copy_range.max))
     {
-      // TODO(rjf)
-#if 0
       Temp temp = temp_begin(scratch.arena);
-      DF_Entity *flash_range = df_entity_alloc(entity, DF_EntityKind_FlashMarker);
+      DF_Entity *flash_range = df_entity_alloc(0, process, DF_EntityKind_FlashMarker);
       df_entity_equip_death_timer(flash_range, 0.5f);
       df_entity_equip_color_rgba(flash_range, df_rgba_from_theme_color(DF_ThemeColor_Highlight0));
       df_entity_equip_txt_pt(flash_range, sig.copy_range.min);
       df_entity_equip_txt_pt_alt(flash_range, sig.copy_range.max);
-      String8 text = txti_string_from_handle_txt_rng(temp.arena, txti_handle, sig.copy_range);
+      String8 text = df_get_lines_in_range(temp.arena, code_slice_params.line_text, code_slice_params.line_num_range, &sig.copy_range);
       os_set_clipboard_text(text);
       temp_end(temp);
-#endif
     }
     
     //- rjf: toggle cursor watch


### PR DESCRIPTION
I noticed that copy function does not work in the "Disassembly" view. I took a little look at the source code and tried to implement it. At the end, I have something works but I'm not sure if this is actually the right way to do it. When I look at the "Code" view, it seems to find the relevant lines to copy by taking a `TXTI_Handle` and calling some function using that handle. Is there a way to get a `TXTI_Handle` for the "Disassembly" view? I guess only file entities can get `TXTI_Handle` at least for now. So, instead of using `TXTI_Handle` I used `DF_CodeSliceParams` to get visible lines and put them to the clipboard.