### PR TITLE
Show exception dialog with call stack on crash

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -47,8 +47,8 @@ set cl_debug=      call cl /Od %cl_common%
 set cl_release=    call cl /O2 /DNDEBUG %cl_common%
 set clang_debug=   call clang -g -O0 %clang_common%
 set clang_release= call clang -g -O3 -DNDEBUG %clang_common% 
-set cl_link=       /link /INCREMENTAL:NO /natvis:"%~dp0\src\natvis\base.natvis"
-set clang_link=    -Xlinker /natvis:"%~dp0\src\natvis\base.natvis"
+set cl_link=       /link /MANIFEST:EMBED /INCREMENTAL:NO /natvis:"%~dp0\src\natvis\base.natvis"
+set clang_link=    -Xlinker /MANIFEST:EMBED -Xlinker /natvis:"%~dp0\src\natvis\base.natvis"
 set cl_out=        /out:
 set clang_out=     -o
 

--- a/src/os/core/win32/os_core_win32.c
+++ b/src/os/core/win32/os_core_win32.c
@@ -6,6 +6,11 @@
 #pragma comment(lib, "shell32")
 #pragma comment(lib, "advapi32")
 #pragma comment(lib, "rpcrt4")
+#pragma comment(lib, "shlwapi")
+#pragma comment(lib, "comctl32")
+
+// this is required for loading correct comctl32 dll file
+#pragma comment(linker,"\"/manifestdependency:type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'\"")
 
 ////////////////////////////////
 //~ allen: Definitions For Symbols That Are Sometimes Missing in Older Windows SDKs

--- a/src/raddbg/raddbg.h
+++ b/src/raddbg/raddbg.h
@@ -428,6 +428,7 @@
 #else
 # define RADDBG_TITLE_STRING_LITERAL "The RAD Debugger (" RADDBG_VERSION_STRING_LITERAL " ALPHA) - " __DATE__ " [Debug]"
 #endif
+#define RADDBG_GITHUB_ISSUES "https://github.com/EpicGames/raddebugger/issues"
 
 ////////////////////////////////
 //~ rjf: Top-Level Execution Types

--- a/src/raddbg/raddbg_main.cpp
+++ b/src/raddbg/raddbg_main.cpp
@@ -92,17 +92,209 @@
 //- rjf: windows
 #if OS_WINDOWS
 
-global DWORD g_saved_exception_code = 0;
+#include <dbghelp.h>
 
-internal DWORD
-win32_exception_filter(DWORD dwExceptionCode)
+#undef OS_WINDOWS // shlwapi uses its own OS_WINDOWS include inside
+#include <shlwapi.h>
+
+internal B32 g_is_quiet = 0;
+
+internal HRESULT WINAPI
+win32_dialog_callback(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam, LONG_PTR data)
 {
-  g_saved_exception_code = dwExceptionCode;
-  return EXCEPTION_EXECUTE_HANDLER;
+  if(msg == TDN_HYPERLINK_CLICKED)
+  {
+    ShellExecuteW(NULL, L"open", (LPWSTR)lparam, NULL, NULL, SW_SHOWNORMAL);
+  }
+  return S_OK;
+}
+
+internal LONG WINAPI
+win32_exception_filter(EXCEPTION_POINTERS* exception_info)
+{
+  if(g_is_quiet)
+  {
+    ExitProcess(1);
+  }
+
+  static volatile LONG first = 0;
+  if(InterlockedCompareExchange(&first, 1, 0) != 0)
+  {
+    // prevent failures in other threads to popup same message box
+    // this handler just shows first thread that crashes
+    // we are terminating afterwards anyway
+    for (;;) Sleep(1000);
+  }
+  
+  WCHAR buffer[4096] = {0};
+  int buflen = 0;
+
+  DWORD exception_code = exception_info->ExceptionRecord->ExceptionCode;
+  buflen += wnsprintfW(buffer + buflen, sizeof(buffer) - buflen, L"A fatal exception (code 0x%x) occurred. The process is terminating.\n", exception_code);
+
+  // load dbghelp dynamically just in case if it is missing
+  HMODULE dbghelp = LoadLibraryA("dbghelp.dll");
+  if(dbghelp)
+  {
+    DWORD (WINAPI *dbg_SymSetOptions)(DWORD SymOptions);
+    BOOL (WINAPI *dbg_SymInitializeW)(HANDLE hProcess, PCWSTR UserSearchPath, BOOL fInvadeProcess);
+    BOOL (WINAPI *dbg_StackWalk64)(DWORD MachineType, HANDLE hProcess, HANDLE hThread,
+      LPSTACKFRAME64 StackFrame, PVOID ContextRecord, PREAD_PROCESS_MEMORY_ROUTINE64 ReadMemoryRoutine,
+      PFUNCTION_TABLE_ACCESS_ROUTINE64 FunctionTableAccessRoutine, PGET_MODULE_BASE_ROUTINE64 GetModuleBaseRoutine,
+      PTRANSLATE_ADDRESS_ROUTINE64 TranslateAddress);
+    PVOID (WINAPI *dbg_SymFunctionTableAccess64)(HANDLE hProcess, DWORD64 AddrBase);
+    DWORD64 (WINAPI *dbg_SymGetModuleBase64)(HANDLE hProcess, DWORD64 qwAddr);
+    BOOL (WINAPI *dbg_SymFromAddrW)(HANDLE hProcess, DWORD64 Address, PDWORD64 Displacement, PSYMBOL_INFOW Symbol);
+    BOOL (WINAPI *dbg_SymGetLineFromAddrW64)(HANDLE hProcess, DWORD64 dwAddr, PDWORD pdwDisplacement, PIMAGEHLP_LINEW64 Line);
+    BOOL (WINAPI *dbg_SymGetModuleInfoW64)(HANDLE hProcess, DWORD64 qwAddr, PIMAGEHLP_MODULEW64 ModuleInfo);
+
+    *(FARPROC*)&dbg_SymSetOptions            = GetProcAddress(dbghelp, "SymSetOptions");
+    *(FARPROC*)&dbg_SymInitializeW           = GetProcAddress(dbghelp, "SymInitializeW");
+    *(FARPROC*)&dbg_StackWalk64              = GetProcAddress(dbghelp, "StackWalk64");
+    *(FARPROC*)&dbg_SymFunctionTableAccess64 = GetProcAddress(dbghelp, "SymFunctionTableAccess64");
+    *(FARPROC*)&dbg_SymGetModuleBase64       = GetProcAddress(dbghelp, "SymGetModuleBase64");
+    *(FARPROC*)&dbg_SymFromAddrW             = GetProcAddress(dbghelp, "SymFromAddrW");
+    *(FARPROC*)&dbg_SymGetLineFromAddrW64    = GetProcAddress(dbghelp, "SymGetLineFromAddrW64");
+    *(FARPROC*)&dbg_SymGetModuleInfoW64      = GetProcAddress(dbghelp, "SymGetModuleInfoW64");
+
+    if(dbg_SymSetOptions && dbg_SymInitializeW && dbg_StackWalk64 && dbg_SymFunctionTableAccess64 && dbg_SymGetModuleBase64 && dbg_SymFromAddrW && dbg_SymGetLineFromAddrW64 && dbg_SymGetModuleInfoW64)
+    {
+      HANDLE process = GetCurrentProcess();
+      HANDLE thread = GetCurrentThread();
+      CONTEXT* context = exception_info->ContextRecord;
+
+      dbg_SymSetOptions(SYMOPT_EXACT_SYMBOLS | SYMOPT_FAIL_CRITICAL_ERRORS | SYMOPT_LOAD_LINES | SYMOPT_UNDNAME);
+      if(dbg_SymInitializeW(process, L"", TRUE))
+      {
+        // check that raddbg.pdb file is good
+        B32 raddbg_pdb_valid = 0;
+        {
+          IMAGEHLP_MODULEW64 module = {0};
+          module.SizeOfStruct = sizeof(module);
+          if(dbg_SymGetModuleInfoW64(process, (DWORD64)&win32_exception_filter, &module))
+          {
+            raddbg_pdb_valid = (module.SymType == SymPdb);
+          }
+        }
+
+        if(!raddbg_pdb_valid)
+        {
+          buflen += wnsprintfW(buffer + buflen, sizeof(buffer) - buflen,
+            L"\nraddbg.pdb debug file is not valid or not found. Please rebuild binary to get call stack.\n");
+        }
+        else
+        {
+          STACKFRAME64 frame = {0};
+          DWORD image_type;
+#if defined(_M_AMD64)
+          image_type = IMAGE_FILE_MACHINE_AMD64;
+          frame.AddrPC.Offset = context->Rip;
+          frame.AddrPC.Mode = AddrModeFlat;
+          frame.AddrFrame.Offset = context->Rbp;
+          frame.AddrFrame.Mode = AddrModeFlat;
+          frame.AddrStack.Offset = context->Rsp;
+          frame.AddrStack.Mode = AddrModeFlat;
+#elif defined(_M_ARM64)
+          image_type = IMAGE_FILE_MACHINE_ARM64;
+          frame.AddrPC.Offset = context->Pc;
+          frame.AddrPC.Mode = AddrModeFlat;
+          frame.AddrFrame.Offset = context->Fp;
+          frame.AddrFrame.Mode = AddrModeFlat;
+          frame.AddrStack.Offset = context->Sp;
+          frame.AddrStack.Mode = AddrModeFlat;
+#else
+#  error Architecture not supported!
+#endif
+
+          for(U32 idx=0; ;idx++)
+          {
+            const U32 max_frames = 32;
+            if(idx == max_frames)
+            {
+              buflen += wnsprintfW(buffer + buflen, sizeof(buffer) - buflen, L"...");
+              break;
+            }
+
+            if(!dbg_StackWalk64(image_type, process, thread, &frame, context, 0, dbg_SymFunctionTableAccess64, dbg_SymGetModuleBase64, 0))
+            {
+              break;
+            }
+
+            U64 address = frame.AddrPC.Offset;
+            if(address == 0)
+            {
+              break;
+            }
+
+            if(idx==0)
+            {
+              buflen += wnsprintfW(buffer + buflen, sizeof(buffer) - buflen,
+                L"\nPress Ctrl+C to copy this text to clipboard, then create a new issue in\n"
+                L"<a href=\"%S\">%S</a>\n\n", RADDBG_GITHUB_ISSUES, RADDBG_GITHUB_ISSUES);
+              buflen += wnsprintfW(buffer + buflen, sizeof(buffer) - buflen, L"Call stack:\n");
+            }
+
+            buflen += wnsprintfW(buffer + buflen, sizeof(buffer) - buflen, L"%u. [0x%I64x]", idx, address);
+
+            struct {
+              SYMBOL_INFOW info;
+              WCHAR name[MAX_SYM_NAME];
+            } symbol = {0};
+
+            symbol.info.SizeOfStruct = sizeof(symbol.info);
+            symbol.info.MaxNameLen = MAX_SYM_NAME;
+
+            DWORD64 displacement = 0;
+            if(dbg_SymFromAddrW(process, address, &displacement, &symbol.info))
+            {
+              buflen += wnsprintfW(buffer + buflen, sizeof(buffer) - buflen, L" %s +%u", symbol.info.Name, (DWORD)displacement);
+
+              IMAGEHLP_LINEW64 line = {0};
+              line.SizeOfStruct = sizeof(line);
+
+              DWORD line_displacement = 0;
+              if(dbg_SymGetLineFromAddrW64(process, address, &line_displacement, &line))
+              {
+                buflen += wnsprintfW(buffer + buflen, sizeof(buffer) - buflen, L", %s line %u", PathFindFileNameW(line.FileName), line.LineNumber);
+              }
+            }
+            else
+            {
+              IMAGEHLP_MODULEW64 module = {0};
+              module.SizeOfStruct = sizeof(module);
+              if(dbg_SymGetModuleInfoW64(process, address, &module))
+              {
+                buflen += wnsprintfW(buffer + buflen, sizeof(buffer) - buflen, L" %s", module.ModuleName);
+              }
+            }
+
+            buflen += wnsprintfW(buffer + buflen, sizeof(buffer) - buflen, L"\n");
+          }
+        }
+      }
+    }
+  }
+
+  // remove last newline
+  buffer[buflen] = 0;
+
+  TASKDIALOGCONFIG dialog = {0};
+  dialog.cbSize = sizeof(dialog);
+  dialog.dwFlags = TDF_SIZE_TO_CONTENT | TDF_ENABLE_HYPERLINKS | TDF_ALLOW_DIALOG_CANCELLATION;
+  dialog.pszMainIcon = TD_ERROR_ICON;
+  dialog.dwCommonButtons = TDCBF_CLOSE_BUTTON;
+  dialog.pszWindowTitle = L"Fatal Exception";
+  dialog.pszContent = buffer;
+  dialog.pfCallback = &win32_dialog_callback;
+  TaskDialogIndirect(&dialog, 0, 0, 0);
+
+  ExitProcess(1);
 }
 
 int WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nShowCmd)
 {
+  SetUnhandledExceptionFilter(&win32_exception_filter);
+
   HANDLE output_handles[3] =
   {
     GetStdHandle(STD_INPUT_HANDLE),
@@ -142,31 +334,17 @@ int WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int n
   int argc;
   WCHAR **argv_16 = CommandLineToArgvW(command_line, &argc);
   char **argv = push_array(perm_arena, char *, argc);
-  B32 is_quiet = 0;
   for(int i = 0; i < argc; i += 1)
   {
     String16 arg16 = str16_cstring((U16 *)argv_16[i]);
     String8 arg8 = str8_from_16(perm_arena, arg16);
     if(str8_match(arg8, str8_lit("--quiet"), StringMatchFlag_CaseInsensitive))
     {
-      is_quiet = 1;
+      g_is_quiet = 1;
     }
     argv[i] = (char *)arg8.str;
   }
-  __try
-  {
-    entry_point(argc, argv);
-  }
-  __except(win32_exception_filter(GetExceptionCode()))
-  {
-    if(!is_quiet)
-    {
-      char buffer[256] = {0};
-      raddbg_snprintf(buffer, sizeof(buffer), "A fatal exception (code 0x%x) occurred. The process is terminating.", (U32)g_saved_exception_code);
-      os_graphical_message(1, str8_lit("Fatal Exception"), str8_cstring(buffer));
-    }
-    ExitProcess(1);
-  }
+  entry_point(argc, argv);
   return 0;
 }
 

--- a/src/render/d3d11/render_d3d11.cpp
+++ b/src/render/d3d11/render_d3d11.cpp
@@ -176,7 +176,7 @@ r_init(CmdLine *cmdln)
   if(FAILED(error))
   {
     char buffer[256] = {0};
-    raddbg_snprintf(buffer, sizeof(buffer), "D3D11 device creation failure (%x). The process is terminating.", error);
+    raddbg_snprintf(buffer, sizeof(buffer), "D3D11 device creation failure (%lx). The process is terminating.", error);
     os_graphical_message(1, str8_lit("Fatal Error"), str8_cstring(buffer));
     os_exit_process(1);
   }
@@ -483,7 +483,7 @@ r_window_equip(OS_Handle handle)
     if(FAILED(error))
     {
       char buffer[256] = {0};
-      raddbg_snprintf(buffer, sizeof(buffer), "DXGI swap chain creation failure (%x). The process is terminating.", error);
+      raddbg_snprintf(buffer, sizeof(buffer), "DXGI swap chain creation failure (%lx). The process is terminating.", error);
       os_graphical_message(1, str8_lit("Fatal Error"), str8_cstring(buffer));
       os_exit_process(1);
     }
@@ -998,7 +998,7 @@ r_window_end_frame(OS_Handle window, R_Handle window_equip)
     if(FAILED(error))
     {
       char buffer[256] = {0};
-      raddbg_snprintf(buffer, sizeof(buffer), "D3D11 present failure (%x). The process is terminating.", error);
+      raddbg_snprintf(buffer, sizeof(buffer), "D3D11 present failure (%lx). The process is terminating.", error);
       os_graphical_message(1, str8_lit("Fatal Error"), str8_cstring(buffer));
       os_exit_process(1);
     }


### PR DESCRIPTION
Exception handler does not use existing arena/string8/raddbg_sprintf code to avoid triggering extra failure in case some kind of memory corruption happened in their implementation or data structures.

Example:

![image](https://github.com/EpicGames/raddebugger/assets/1665010/91ced0e8-ee98-4260-8b5c-d88b15619966)
