### PR TITLE
Show decimal value as well for naked enum types

### DIFF
--- a/src/df/core/df_core.c
+++ b/src/df/core/df_core.c
@@ -4734,10 +4734,14 @@ df_string_from_simple_typed_eval(Arena *arena, TG_Graph *graph, RADDBG_Parsed *r
       }
       if(flags & DF_EvalVizStringFlag_ReadOnlyDisplayRules)
       {
-        result = push_str8f(arena, "0x%I64x%s%S%s", eval.imm_u64,
-                            constant_name.size != 0 ? " (" : "",
-                            constant_name,
-                            constant_name.size != 0 ? ")" : "");
+        if (constant_name.size != 0)
+        {
+          result = push_str8f(arena, "0x%I64x (%S)", eval.imm_u64, constant_name);
+        }
+        else
+        {
+          result = push_str8f(arena, "0x%I64x (%llu)", eval.imm_u64, eval.imm_u64);
+        }
       }
       else if(constant_name.size != 0)
       {


### PR DESCRIPTION
Show decimal value with hex for cases like `enum class entt::entity : uint32_t {}`

Issue:
![NakedEnumIssue](https://github.com/EpicGames/raddebugger/assets/29519295/f4c255a0-4ae4-415e-a782-b46d57832d7f)
Fix:
![NakedEnumFixed](https://github.com/EpicGames/raddebugger/assets/29519295/a4d17421-7940-48e1-8e88-39b5be8ab413)
