### PR TITLE
Reduce pixel overdraw while rendering text

### DIFF
--- a/src/font_cache/font_cache.c
+++ b/src/font_cache/font_cache.c
@@ -747,7 +747,10 @@ f_push_run_from_string(Arena *arena, F_Tag tag, F32 size, F_RunFlags flags, Stri
         }
         if(info != 0)
         {
-          info->subrect = chosen_atlas_region;
+          info->subrect.min.x = chosen_atlas_region.min.x;
+          info->subrect.min.y = chosen_atlas_region.min.y;
+          info->subrect.max.x = chosen_atlas_region.min.x + raster.atlas_dim.x;
+          info->subrect.max.y = chosen_atlas_region.min.y + raster.atlas_dim.y;
           info->atlas_num = chosen_atlas_num;
           info->advance = raster.advance;
         }

--- a/src/font_provider/dwrite/font_provider_dwrite.cpp
+++ b/src/font_provider/dwrite/font_provider_dwrite.cpp
@@ -420,6 +420,7 @@ fp_raster(Arena *arena, FP_Handle font_handle, F32 size, FP_RasterMode mode, Str
       U64 in_pitch  = (U64)dib.dsBm.bmWidthBytes;
       U8 *out_data  = (U8 *)result.atlas;
       U64 out_pitch = atlas_dim.x * 4;
+      U64 color_sum = 0;
       
       U8 *in_line = (U8 *)in_data;
       U8 *out_line = out_data;
@@ -434,11 +435,17 @@ fp_raster(Arena *arena, FP_Handle font_handle, F32 size, FP_RasterMode mode, Str
           out_pixel[1] = 255;
           out_pixel[2] = 255;
           out_pixel[3] = in_pixel_byte;
+          color_sum += in_pixel_byte;
           in_pixel += 4;
           out_pixel += 4;
         }
         in_line += in_pitch;
         out_line += out_pitch;
+      }
+
+      if (color_sum == 0)
+      {
+        result.atlas_dim = {0};
       }
     }
     render_target->Release();


### PR DESCRIPTION
There are two small changes here to reduce overdraw. The first one stores the more compact rectangle as the glyph subrect to prevent drawing the entire atlas cell. The second one detects bitmaps that are empty and doesn't allocate any atlas region for it. This prevents the space character from being drawn by d_img.

The first image here shows the reduced wireframe sizes for the new version (on the right). The second image is the amount of overdraw for the render pass. Purple, blue, and green are low overdraw while yellow, red, and white are significant overdraw.

This should reduce the GPU load, which is significant on my laptop with an integrated video card.

![wireframe](https://github.com/EpicGames/raddebugger/assets/1819790/f335aa39-5111-4e7f-ac78-2d1fc30d888c)

![overdraw](https://github.com/EpicGames/raddebugger/assets/1819790/ab2ea833-ec1e-4353-9708-7cf52fd386d6)
