### PR TITLE
Build fixes

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -20,9 +20,9 @@ jobs:
         shell: cmd
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
-          call build raddbg msvc debug
-          call build raddbg_from_pdb msvc debug
-          call build raddbg_from_dwarf msvc debug
-          call build raddbg clang debug
-          call build raddbg_from_pdb clang debug
-          call build raddbg_from_dwarf clang debug
+          call build raddbg msvc debug             || exit /b 1
+          call build raddbg_from_pdb msvc debug    || exit /b 1
+          call build raddbg_from_dwarf msvc debug  || exit /b 1
+          call build raddbg clang debug            || exit /b 1
+          call build raddbg_from_pdb clang debug   || exit /b 1
+          call build raddbg_from_dwarf clang debug || exit /b 1

--- a/build.bat
+++ b/build.bat
@@ -60,6 +60,8 @@ if "%msvc%"=="1"  set only_compile=/c
 if "%clang%"=="1" set only_compile=-c
 if "%msvc%"=="1"  set EHsc=/EHsc
 if "%clang%"=="1" set EHsc=
+if "%msvc%"=="1"  set rc=rc.exe
+if "%clang%"=="1" set rc=llvm-rc.exe
 
 :: --- Choose Compile/Link Lines ----------------------------------------------
 if "%msvc%"=="1"      set compile_debug=%cl_debug%
@@ -79,7 +81,7 @@ if not exist local mkdir local
 
 :: --- Produce Logo Icon File -------------------------------------------------
 pushd build
-rc /nologo /fo logo.res ..\data\logo.rc
+%rc% /nologo /fo logo.res ..\data\logo.rc || exit /b 1
 popd
 
 :: --- Build & Run Metaprogram ------------------------------------------------

--- a/src/render/d3d11/render_d3d11.cpp
+++ b/src/render/d3d11/render_d3d11.cpp
@@ -1300,8 +1300,8 @@ r_window_submit(OS_Handle window, R_Handle window_equip, R_PassList *passes)
 
           U32 uniform_offset[Axis2_COUNT][2] =
           {
-              { 0 * sizeof(R_D3D11_Uniforms_BlurPass) / 16, OffsetOf(R_D3D11_Uniforms_Blur, kernel) / 16 },
-              { 1 * sizeof(R_D3D11_Uniforms_BlurPass) / 16, OffsetOf(R_D3D11_Uniforms_Blur, kernel) / 16 },
+              { 0 * sizeof(R_D3D11_Uniforms_BlurPass) / 16, (U32)OffsetOf(R_D3D11_Uniforms_Blur, kernel) / 16 },
+              { 1 * sizeof(R_D3D11_Uniforms_BlurPass) / 16, (U32)OffsetOf(R_D3D11_Uniforms_Blur, kernel) / 16 },
           };
 
           U32 uniform_count[Axis2_COUNT][2] =


### PR DESCRIPTION
1) check for errors when running build.bat in github action, so action fails on error
2) fixes warning/error for clang build
3) use llvm-rc.exe to not depend on rc.exe for clang build
