### PR TITLE
fix utf8 encoding missing one bit shift

### DIFF
--- a/src/base/base_string.c
+++ b/src/base/base_string.c
@@ -1366,7 +1366,7 @@ utf8_encode(U8 *str, U32 codepoint){
     inc = 3;
   }
   else if (codepoint <= 0x10FFFF){
-    str[0] = (bitmask4 << 3) | ((codepoint >> 18) & bitmask3);
+    str[0] = (bitmask4 << 4) | ((codepoint >> 18) & bitmask3);
     str[1] = bit8 | ((codepoint >> 12) & bitmask6);
     str[2] = bit8 | ((codepoint >>  6) & bitmask6);
     str[3] = bit8 | ( codepoint        & bitmask6);


### PR DESCRIPTION
![image](https://github.com/EpicGames/raddebugger/assets/51819886/215495b9-69f8-45cd-a139-c46b1809f53a)

It was tested. for example with  `U:1F602` 