### PR TITLE
make msvc release build much faster

### DIFF
--- a/src/df/gfx/df_gfx.c
+++ b/src/df/gfx/df_gfx.c
@@ -1012,6 +1012,10 @@ df_window_from_os_handle(OS_Handle os)
   return result;
 }
 
+#if defined(_MSC_VER) && !defined(__clang__) && defined(NDEBUG)
+#pragma optimize("", off)
+#endif
+
 internal void
 df_window_update_and_render(Arena *arena, OS_EventList *events, DF_Window *ws, DF_CmdList *cmds)
 {
@@ -6636,6 +6640,10 @@ df_window_update_and_render(Arena *arena, OS_EventList *events, DF_Window *ws, D
   
   ProfEnd();
 }
+
+#if defined(_MSC_VER) && !defined(__clang__) && defined(NDEBUG)
+#pragma optimize("", on)
+#endif
 
 ////////////////////////////////
 //~ rjf: Eval Viz


### PR DESCRIPTION
cl.exe for some reason spends unreasonable amount of time optimizing `df_window_update_and_render` function. We can use pragma to skip optimizations for this function.

This change improves `build.bat release raddbg msvc` time from ~50 seconds to ~7 seconds for me.

Alternatively we could split this function into few smaller ones to find out what triggers this slowness and leave only smaller amount of code under this pragma.