### PR TITLE
Fix for no MapOnDefaultTextures support (Intel Graphics 4000 crash)

### DIFF
--- a/src/render/d3d11/render_d3d11.h
+++ b/src/render/d3d11/render_d3d11.h
@@ -153,6 +153,9 @@ struct R_D3D11_State
   Arena *buffer_flush_arena;
   R_D3D11_FlushBuffer *first_buffer_to_flush;
   R_D3D11_FlushBuffer *last_buffer_to_flush;
+
+  // amason: support
+  D3D11_FEATURE_DATA_D3D11_OPTIONS2 feature_support;
 };
 
 ////////////////////////////////


### PR DESCRIPTION
I ran into an issue with an older iGPU (Intel HD Graphics 4000):

> Fatal Exception
> 
> [Content]
> A fatal exception (code 0xc0000005) occurred. The process is terminating.
> 
> Press Ctrl+C to copy this text to clipboard, then create a new issue at
> https://github.com/EpicGames/raddebugger/issues
> 
> Call stack:
> 1. [0x7ffc09c998a0] d3d11
> 2. [0x7ff7e267e314] r_fill_tex2d_region +452, render_d3d11.cpp line 689
> 3. [0x7ff7e268886a] f_push_run_from_string +3130, font_cache.c line 744
> 4. [0x7ff7e272986f] df_window_open +1391, df_gfx.c line 987
> 5. [0x7ff7e278d2f4] df_gfx_begin_frame +9076, df_gfx.c line 13321
> 6. [0x7ff7e27a387a] update_and_render +4234, raddbg.c line 301
> 7. [0x7ff7e25ec784] entry_point +6196, raddbg_main.cpp line 397
> 8. [0x7ff7e25e6d3b] main_thread_base_entry_point +491, base_entry_point.c line 84
> 9. [0x7ff7e27a62b0] w32_entry_point_caller +512, os_core_win32.c line 1794
> 10. [0x7ff7e25d6776] wWinMain +54, os_core_win32.c line 1806
> 11. [0x7ff7e27c5802] __scrt_common_main_seh +262, exe_common.inl line 288
> 12. [0x7ffc0eef7344] KERNEL32
> 13. [0x7ffc102a26b1] ntdll
> 
> Version: 0.9.10 [489ae56-dirty]

Enabling `-d3d11_debug`, it's caused by this D3D error:
> D3D11 ERROR: ID3D11Device::CreateTexture2D: CheckFeatureSupport() API with D3D11_FEATURE_D3D11_OPTIONS2 must report support for MapOnDefaultTextures for a D3D11_USAGE_DEFAULT Texture Resource to have CPUAccessFlags set. CPUAccessFlags are currently set to: D3D11_CPU_ACCESS_READ (0), D3D11_CPU_ACCESS_WRITE (1). MapOnDefaultBuffers is (false). [ STATE_CREATION ERROR #98: CREATETEXTURE2D_INVALIDCPUACCESSFLAGS]

I went ahead and worked around it by using Map() instead of UpdateSubresource. It's not an ideal solution, since it's mapping and unmapping each time a glyph is written into the texture, but at least it got it working. Just tossing this your way as a bug report moreso than a PR.