### PR TITLE
make embed_file paths relative to build dir instead of CWD

### DIFF
--- a/src/metagen/metagen_main.c
+++ b/src/metagen/metagen_main.c
@@ -427,7 +427,11 @@ entry_point(CmdLine *cmdline)
       {
         String8 layer_key = mg_layer_key_from_path(file->string);
         MG_Layer *layer = mg_layer_from_key(layer_key);
-        String8 data = os_data_from_file_path(mg_arena, node->first->string);
+        String8List path_list = {0};
+        str8_list_push(mg_arena, &path_list, build_dir_path);
+        str8_list_push(mg_arena, &path_list, node->first->string);
+        String8 path = str8_path_list_join_by_style(mg_arena, &path_list, PathStyle_SystemAbsolute);
+        String8 data = os_data_from_file_path(mg_arena, path);
         String8 embed_string = mg_c_array_literal_contents_from_data(data);
         str8_list_pushf(mg_arena, &layer->h_tables, "read_only global U8 %S__data[] =\n{\n", node->string);
         str8_list_push (mg_arena, &layer->h_tables, embed_string);


### PR DESCRIPTION
Currently metagen resolves embed_file paths relative to CWD.  This differs from how it finds mdesk files which searches for them relative to the build directory where the metagen.exe lives.  This discrepancy causes metagen to produce unexpected results if it is invoked from another directory.  I've solved this discrepancy by treating all embed_file paths relative to the build directory.

> NOTE: you can reproduce this issue by running this command which will cause `df_gfx.meta.h` to lose all it's embedded file content `build && cmd /c "cd src\os && ..\..\build\metagen"`