### PR TITLE
Fix issues with UTF-8 display and navigation

### DIFF
--- a/src/base/base_strings.c
+++ b/src/base/base_strings.c
@@ -1228,7 +1228,7 @@ utf8_decode(U8 *str, U64 max){
     }break;
     case 2:
     {
-      if (2 < max)
+      if (1 < max)
       {
         U8 cont_byte = str[1];
         if (utf8_class[cont_byte >> 3] == 0)

--- a/src/ui/ui_core.c
+++ b/src/ui/ui_core.c
@@ -175,8 +175,35 @@ ui_single_line_txt_op_from_event(Arena *arena, UI_Event *event, String8 string, 
     default:{}break;
     case UI_EventDeltaUnit_Char:
     {
-      // TODO(rjf): this should account for multi-byte characters in UTF-8... for now, just assume ASCII and
-      // no-op
+      if (delta.x > 0)
+      {
+        UnicodeDecode decode = utf8_decode(string.str + cursor.column - 1, string.size);
+        delta.x = decode.inc;
+      }
+      else
+      {
+        //Backwards check/count for UTF-8 multi byte sequence
+        U32 numSeqBytes = 0;
+        for (S64 idx = cursor.column - 2; idx >= 0; idx -= 1)
+        {
+          B32 isSeqByte = ExtractBit(string.str[idx], 7) == 1 && ExtractBit(string.str[idx], 6) == 0;
+          numSeqBytes += isSeqByte;
+          if (!isSeqByte)
+          {
+            if (numSeqBytes > 0)
+            {
+              U32 initialByte = ~(string.str[idx]) << 24;
+              U64 numLeadingBits = clz32(initialByte);
+              B32 isMultiByteSeq = numLeadingBits == numSeqBytes + 1;
+              if (isMultiByteSeq)
+              {
+                delta.x = -(numSeqBytes + 1);
+              }
+            }
+            break;
+          }
+        }
+      }
     }break;
     case UI_EventDeltaUnit_Word:
     {


### PR DESCRIPTION
This fixes two bugs related to UTF-8.

The first bug was in UTF-8 decoding and prevented certain multi byte characters from getting added to the font atlas correctly.
This issue was first noticed when trying to type a german 'Ü' into the target's `Arguments` field and only empty space showed up.
This is exactly the same as #184.
Sorry for the duplication but the rest of this pull request only really makes sense with this change.

The second bug is not so much a bug but more the missing implementation for `UI_EventDeltaUnit_Char`.
It now properly adjusts the delta to correctly jump over multi byte character in both directions.
Without this fix e.g. the previously mentioned 'Ü' acted like two characters when trying to move the cursor.

There still seems to be outstanding issues with rendering multi byte characters where monospaced font is used. For example the watch window.