### PR TITLE
X11: Use custom border and titlebar instead of the default one

### DIFF
--- a/src/os/gfx/linux/os_gfx_linux.c
+++ b/src/os/gfx/linux/os_gfx_linux.c
@@ -628,25 +628,23 @@ os_get_events(Arena *arena, B32 wait)
           F32 y = (F32)evt.xbutton.y;
           OS_Handle handle = {(U64)window};
           Rng2F32 rect = os_client_rect_from_window(handle);
-          F32 win_width = rect.x1 - rect.x0;
-          F32 win_height = rect.y1 - rect.y0;
           F32 edge_size = window->custom_border_edge_thickness;
           int detail = -1;
-          if (x < edge_size && y < edge_size)
+          if (x <= edge_size && y <= edge_size)
               detail = 0; // top-left
-          else if (y < edge_size && x >= (rect.x1 - edge_size))
+          else if (y <= edge_size && x >= (rect.x1 - edge_size))
               detail = 2; // top-right
-          else if (x < edge_size && y >= (rect.y1 - edge_size))
+          else if (x <= edge_size && y >= (rect.y1 - edge_size))
               detail = 6; // bottom-left
           else if (y >= (rect.y1 - edge_size) && x >= (rect.x1 - edge_size))
               detail = 4; // bottom-right
-          else if (y < edge_size)
+          else if (y <= edge_size)
               detail = 1; // top
           else if (x >= (rect.x1 - edge_size))
               detail = 2; // right
           else if (y >= (rect.y1 - edge_size))
               detail = 5; // bottom
-          else if (x < edge_size)
+          else if (x <= edge_size)
               detail = 7; // left
           else
               if (y <= window->custom_border_title_thickness) detail = 8; // move
@@ -701,20 +699,18 @@ os_get_events(Arena *arena, B32 wait)
           OS_Handle handle = {(U64)window};
           Rng2F32 rect = os_client_rect_from_window(handle);
           F32 edge_size = window->custom_border_edge_thickness;
-          B32 on_border_x = (x <= window->custom_border_edge_thickness || rect.x1-window->custom_border_edge_thickness <= x);
-          B32 on_border_y = (y <= window->custom_border_edge_thickness || rect.y1-window->custom_border_edge_thickness <= y);
           OS_Cursor cursor = OS_Cursor_Pointer;
-          if (x < edge_size && y < edge_size)
+          if (x <= edge_size && y <= edge_size)
             cursor = OS_Cursor_UpLeft;
-          else if (y < edge_size && x >= (rect.x1 - edge_size))
+          else if (y <= edge_size && x >= (rect.x1 - edge_size))
             cursor = OS_Cursor_UpRight;
-          else if (x < edge_size && y >= (rect.y1 - edge_size))
+          else if (x <= edge_size && y >= (rect.y1 - edge_size))
             cursor = OS_Cursor_DownLeft;
           else if (y >= (rect.y1 - edge_size) && x >= (rect.x1 - edge_size))
             cursor = OS_Cursor_DownRight;
-          else if (y < edge_size || y >= (rect.y1 - edge_size))
+          else if (y <= edge_size || y >= (rect.y1 - edge_size))
             cursor = OS_Cursor_UpDown;
-          else if (x < edge_size || x >= (rect.x1 - edge_size))
+          else if (x <= edge_size || x >= (rect.x1 - edge_size))
             cursor = OS_Cursor_LeftRight;
 
           os_set_cursor(cursor);

--- a/src/os/gfx/linux/os_gfx_linux.c
+++ b/src/os/gfx/linux/os_gfx_linux.c
@@ -43,16 +43,6 @@ os_lnx_check_x11window_atoms(Window window, Atom atoms[], U64 num_atoms)
   return num_found == num_atoms;
 }
 
-// Motif hints structure and constants for managing decorations 
-typedef struct {
-    unsigned long flags;
-    unsigned long functions;
-    unsigned long decorations;
-    long inputMode;
-    unsigned long status;
-} MotifWmHints;
-
-#define MWM_HINTS_DECORATIONS   (1L << 1)
 
 ////////////////////////////////
 //~ rjf: @os_hooks Main Initialization API (Implemented Per-OS)
@@ -193,8 +183,15 @@ os_window_open(Rng2F32 rect, OS_WindowFlags flags, String8 title)
   if (flags & OS_WindowFlag_CustomBorder) 
   {
     w->custom_border = 1;
-    MotifWmHints hints;
-    hints.flags = MWM_HINTS_DECORATIONS;
+
+    struct {
+      unsigned long flags;
+      unsigned long functions;
+      unsigned long decorations;
+      long inputMode;
+      unsigned long status;
+    } hints; // MotifWmHints
+    hints.flags = 3; // MWM_HINTS_DECORATIONS
     hints.decorations = 0; // no decorations
     XChangeProperty(os_lnx_gfx_state->display, w->window, os_lnx_gfx_state->wm_motif_hints_atom, os_lnx_gfx_state->wm_motif_hints_atom, 32, PropModeReplace, (U8 *)&hints, 5);
   }

--- a/src/os/gfx/linux/os_gfx_linux.h
+++ b/src/os/gfx/linux/os_gfx_linux.h
@@ -51,6 +51,7 @@ struct OS_LNX_GfxState
   Atom wm_state_atom;
   Atom wm_state_hidden_atom;
   Atom wm_state_maximized_vert_atom, wm_state_maximized_horz_atom;
+  Atom wm_state_fullscreen_atom;
   Cursor cursors[OS_Cursor_COUNT];
   OS_Cursor last_set_cursor;
   OS_GfxInfo gfx_info;

--- a/src/os/gfx/linux/os_gfx_linux.h
+++ b/src/os/gfx/linux/os_gfx_linux.h
@@ -66,6 +66,6 @@ global OS_LNX_GfxState *os_lnx_gfx_state = 0;
 //~ rjf: Helpers
 
 internal OS_LNX_Window *os_lnx_window_from_x11window(Window window);
-internal B32 os_lnx_check_x11window_atoms(Window window, Atom properties[], U64 num_properties);
+internal B32 os_lnx_check_x11window_states(Window window, Atom properties[], U64 num_properties);
 
 #endif // OS_GFX_LINUX_H

--- a/src/os/gfx/linux/os_gfx_linux.h
+++ b/src/os/gfx/linux/os_gfx_linux.h
@@ -43,6 +43,7 @@ struct OS_LNX_GfxState
   Atom wm_delete_window_atom;
   Atom wm_sync_request_atom;
   Atom wm_sync_request_counter_atom;
+  Atom wm_motif_hints_atom;
   Cursor cursors[OS_Cursor_COUNT];
   OS_Cursor last_set_cursor;
   OS_GfxInfo gfx_info;

--- a/src/os/gfx/linux/os_gfx_linux.h
+++ b/src/os/gfx/linux/os_gfx_linux.h
@@ -44,6 +44,10 @@ struct OS_LNX_GfxState
   Atom wm_sync_request_atom;
   Atom wm_sync_request_counter_atom;
   Atom wm_motif_hints_atom;
+  Atom wm_move_resize_atom;
+  Atom wm_state_atom;
+  Atom wm_state_hidden_atom;
+  Atom wm_state_maximized_vert_atom, wm_state_maximized_horz_atom;
   Cursor cursors[OS_Cursor_COUNT];
   OS_Cursor last_set_cursor;
   OS_GfxInfo gfx_info;
@@ -58,5 +62,6 @@ global OS_LNX_GfxState *os_lnx_gfx_state = 0;
 //~ rjf: Helpers
 
 internal OS_LNX_Window *os_lnx_window_from_x11window(Window window);
+internal B32 os_lnx_check_x11window_atoms(Window window, Atom properties[], U64 num_properties);
 
 #endif // OS_GFX_LINUX_H

--- a/src/os/gfx/linux/os_gfx_linux.h
+++ b/src/os/gfx/linux/os_gfx_linux.h
@@ -26,6 +26,9 @@ struct OS_LNX_Window
   XIC xic;
   XID counter_xid;
   U64 counter_value;
+  B32 custom_border;
+  F32 custom_border_title_thickness;
+  F32 custom_border_edge_thickness;
 };
 
 ////////////////////////////////

--- a/src/os/gfx/os_gfx.h
+++ b/src/os/gfx/os_gfx.h
@@ -36,6 +36,8 @@ typedef enum OS_Cursor
   OS_Cursor_UpDown,
   OS_Cursor_DownRight,
   OS_Cursor_UpRight,
+  OS_Cursor_DownLeft,
+  OS_Cursor_UpLeft,
   OS_Cursor_UpDownLeftRight,
   OS_Cursor_HandPoint,
   OS_Cursor_Disabled,

--- a/src/os/gfx/win32/os_gfx_win32.c
+++ b/src/os/gfx/win32/os_gfx_win32.c
@@ -1540,6 +1540,8 @@ X(LeftRight, IDC_SIZEWE) \
 X(UpDown, IDC_SIZENS) \
 X(DownRight, IDC_SIZENWSE) \
 X(UpRight, IDC_SIZENESW) \
+X(DownLeft, IDC_SIZENESW) \
+X(UpLeft, IDC_SIZENWSE) \
 X(UpDownLeftRight, IDC_SIZEALL) \
 X(HandPoint, IDC_HAND)\
 X(Disabled, IDC_NO)


### PR DESCRIPTION
Fixing this [tweet](https://x.com/ryanjfleury/status/1921338535233180078).

There is a bug in WSL when your cursor goes outside the window but is still inside the shadow of the window. 
It keeps the last cursor from the application but doesn't send any movement event, so it looks like you could resize when in reality you can't. This was a thing with the default decorations too, I guess it shouldn't happen on a real linux machine.