### PR TITLE
Support bash versions prior to 4.2

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,13 +3,25 @@ set -eu
 cd "$(dirname "$0")"
 
 # --- Unpack Arguments --------------------------------------------------------
+gcc=0
+clang=0
+release=0
+debug=0
+no_meta=0
+raddbg=0
+radlink=0
+rdi_from_pdb=0
+rdi_from_dwarf=0
+rdi_dump=0
+rdi_breakpad_from_pdb=0
+ryan_scratch=0
 for arg in "$@"; do declare $arg='1'; done
-if [ ! -v gcc ];     then clang=1; fi
-if [ ! -v release ]; then debug=1; fi
-if [ -v debug ];     then echo "[debug mode]"; fi
-if [ -v release ];   then echo "[release mode]"; fi
-if [ -v clang ];     then compiler="${CC:-clang}"; echo "[clang compile]"; fi
-if [ -v gcc ];       then compiler="${CC:-gcc}"; echo "[gcc compile]"; fi
+if [ "$gcc" != "1" ];     then clang=1; fi
+if [ "$release" != "1" ]; then debug=1; fi
+if [ "$debug" = "1" ];     then echo "[debug mode]"; fi
+if [ "$release" = "1" ];   then echo "[release mode]"; fi
+if [ "$clang" = "1" ];     then compiler="${CC:-clang}"; echo "[clang compile]"; fi
+if [ "$gcc" = "1" ];       then compiler="${CC:-gcc}"; echo "[gcc compile]"; fi
 
 # --- Unpack Command Line Build Arguments -------------------------------------
 auto_compile_flags=''
@@ -37,24 +49,24 @@ link_render="-lGL -lEGL"
 link_font_provider="-lfreetype"
 
 # --- Choose Compile/Link Lines -----------------------------------------------
-if [ -v gcc ];     then compile_debug="$gcc_debug"; fi
-if [ -v gcc ];     then compile_release="$gcc_release"; fi
-if [ -v gcc ];     then compile_link="$gcc_link"; fi
-if [ -v gcc ];     then out="$gcc_out"; fi
-if [ -v clang ];   then compile_debug="$clang_debug"; fi
-if [ -v clang ];   then compile_release="$clang_release"; fi
-if [ -v clang ];   then compile_link="$clang_link"; fi
-if [ -v clang ];   then out="$clang_out"; fi
-if [ -v debug ];   then compile="$compile_debug"; fi
-if [ -v release ]; then compile="$compile_release"; fi
+if [ "$gcc" = "1" ];     then compile_debug="$gcc_debug"; fi
+if [ "$gcc" = "1" ];     then compile_release="$gcc_release"; fi
+if [ "$gcc" = "1" ];     then compile_link="$gcc_link"; fi
+if [ "$gcc" = "1" ];     then out="$gcc_out"; fi
+if [ "$clang" = "1" ];   then compile_debug="$clang_debug"; fi
+if [ "$clang" = "1" ];   then compile_release="$clang_release"; fi
+if [ "$clang" = "1" ];   then compile_link="$clang_link"; fi
+if [ "$clang" = "1" ];   then out="$clang_out"; fi
+if [ "$debug" = "1" ];   then compile="$compile_debug"; fi
+if [ "$release" = "1" ]; then compile="$compile_release"; fi
 
 # --- Prep Directories --------------------------------------------------------
 mkdir -p build
 mkdir -p local
 
 # --- Build & Run Metaprogram -------------------------------------------------
-if [ -v no_meta ]; then echo "[skipping metagen]"; fi
-if [ ! -v no_meta ]
+if [ "$no_meta" = "1" ]; then echo "[skipping metagen]"; fi
+if [ "$no_meta" != "1" ]
 then
   cd build
   $compile_debug ../src/metagen/metagen_main.c $compile_link $out metagen
@@ -63,18 +75,19 @@ then
 fi
 
 # --- Build Everything (@build_targets) ---------------------------------------
+didbuild=0
 cd build
-if [ -v raddbg ];                then didbuild=1 && $compile ../src/raddbg/raddbg_main.c                                    $compile_link $link_os_gfx $link_render $link_font_provider $out raddbg; fi
-if [ -v radlink ];               then didbuild=1 && $compile ../src/linker/lnk.c                                            $compile_link $out radlink; fi
-if [ -v rdi_from_pdb ];          then didbuild=1 && $compile ../src/rdi_from_pdb/rdi_from_pdb_main.c                        $compile_link $out rdi_from_pdb; fi
-if [ -v rdi_from_dwarf ];        then didbuild=1 && $compile ../src/rdi_from_dwarf/rdi_from_dwarf.c                         $compile_link $out rdi_from_dwarf; fi
-if [ -v rdi_dump ];              then didbuild=1 && $compile ../src/rdi_dump/rdi_dump_main.c                                $compile_link $out rdi_dump; fi
-if [ -v rdi_breakpad_from_pdb ]; then didbuild=1 && $compile ../src/rdi_breakpad_from_pdb/rdi_breakpad_from_pdb_main.c      $compile_link $out rdi_breakpad_from_pdb; fi
-if [ -v ryan_scratch ];          then didbuild=1 && $compile ../src/scratch/ryan_scratch.c                                  $compile_link $link_os_gfx $link_render $link_font_provider $out ryan_scratch; fi
+if [ "$raddbg" = "1" ];                 then didbuild=1 && $compile ../src/raddbg/raddbg_main.c                                    $compile_link $link_os_gfx $link_render $link_font_provider $out raddbg; fi
+if [ "$radlink" = " 1" ];               then didbuild=1 && $compile ../src/linker/lnk.c                                            $compile_link $out radlink; fi
+if [ "$rdi_from_pdb" = " 1" ];          then didbuild=1 && $compile ../src/rdi_from_pdb/rdi_from_pdb_main.c                        $compile_link $out rdi_from_pdb; fi
+if [ "$rdi_from_dwarf" = " 1" ];        then didbuild=1 && $compile ../src/rdi_from_dwarf/rdi_from_dwarf.c                         $compile_link $out rdi_from_dwarf; fi
+if [ "$rdi_dump" = " 1" ];              then didbuild=1 && $compile ../src/rdi_dump/rdi_dump_main.c                                $compile_link $out rdi_dump; fi
+if [ "$rdi_breakpad_from_pdb" = " 1" ]; then didbuild=1 && $compile ../src/rdi_breakpad_from_pdb/rdi_breakpad_from_pdb_main.c      $compile_link $out rdi_breakpad_from_pdb; fi
+if [ "$ryan_scratch" = " 1" ];          then didbuild=1 && $compile ../src/scratch/ryan_scratch.c                                  $compile_link $link_os_gfx $link_render $link_font_provider $out ryan_scratch; fi
 cd ..
 
 # --- Warn On No Builds -------------------------------------------------------
-if [ ! -v didbuild ]
+if [ "$didbuild" = "0" ]
 then
   echo "[WARNING] no valid build target specified; must use build target names as arguments to this script, like \`./build.sh raddbg\` or \`./build.sh rdi_from_pdb\`."
   exit 1


### PR DESCRIPTION
The `if [ -v variable ]` syntax was introduced in bash 4.2, so in order to support prior bash versions, I reverted to the `if [ "$var" = "1" ]` syntax. 

To avoid unbound variable errors caused by `set -u`, I assign 0 to variables before doing argument parsing. There are pre-bash-4.2 ways to check if a variable is set without triggering the unbound variable warning (such as `if [ "${clang+set}"]` ) but that's pretty weird looking, so I thought it was simpler to just declare the variables ahead of time.

I realize that you [removed](https://github.com/EpicGamesExt/raddebugger/commit/926b5e3546be9b6d6f5c910e2268d0859d103e73#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823L6-R12) that syntax, likely due to a combination of wanting the cleaner `-v` syntax, and needing to play nice with the `set -u` unbound variable check, but hopefully the incompatibility with bash <4.2 was an oversight and not a choice (I was just trying to build with bash 3.2)
