### PR TITLE
Minor bugfixes

### DIFF
--- a/src/base/base_context_cracking.h
+++ b/src/base/base_context_cracking.h
@@ -110,9 +110,9 @@
 ////////////////////////////////
 //~ rjf: Arch Cracking
 
-#if defined(ARCH_X64)
+#if defined(ARCH_X64) || defined(ARCH_ARM64)
 # define ARCH_64BIT 1
-#elif defined(ARCH_X86)
+#elif defined(ARCH_X86) || defined(ARCH_ARM32)
 # define ARCH_32BIT 1
 #endif
 

--- a/src/linker/lnk.c
+++ b/src/linker/lnk.c
@@ -1110,6 +1110,11 @@ lnk_inputer_push_lib_thin(LNK_Inputer *inputer, LNK_Config *config, LNK_InputSou
   lnk_log(LNK_Log_InputLib, "Input Lib: %S", first_match);
   input = lnk_inputer_push_thin(inputer->arena, &inputer->new_libs[input_source], inputer->libs_ht, first_match);
 
+  // store input path to early-out of file searches for default libs
+  if (!str8_match(first_match, path, StringMatchFlag_CaseInsensitive)) {
+    hash_table_push_path_raw(inputer->arena, inputer->libs_ht, path, input);
+  }
+
   exit:;
   scratch_end(scratch);
   return input;

--- a/src/linker/lnk.h
+++ b/src/linker/lnk.h
@@ -77,17 +77,18 @@ typedef struct LNK_Inputer
 
 typedef struct LNK_ImportTables
 {
-  Arena     *arena;
+  Arena      *arena;
   String8List delayed_dll_names;
   String8List static_dll_names;
-  HashTable *static_imports;
-  HashTable *delayed_imports;
+  HashTable  *static_imports;
+  HashTable  *delayed_imports;
 } LNK_ImportTables;
 
 typedef struct LNK_Link
 {
   LNK_ObjList             objs;
   LNK_LibList             libs;
+  LNK_ObjNode           **last_symbol_input;
   LNK_IncludeSymbolNode **last_include;
   String8Node           **last_cmd_lib;
   String8Node           **last_default_lib;

--- a/src/linker/lnk.h
+++ b/src/linker/lnk.h
@@ -73,7 +73,8 @@ typedef struct LNK_Inputer
 #define LNK_IMPORT_STUB "*** RAD_IMPORT_STUB ***"
 #define LNK_NULL_SYMBOL "*** RAD_NULL_SYMBOL ***"
 
-#define LNK_SECTION_FLAG_IS_LIVE (1 << 0)
+#define LNK_SECTION_FLAG_IS_LIVE    (1 << 0)
+#define LNK_SECTION_FLAG_DEBUG_INFO (1 << 1)
 
 typedef struct LNK_ImportTables
 {

--- a/src/linker/lnk_debug_info.c
+++ b/src/linker/lnk_debug_info.c
@@ -2934,12 +2934,9 @@ THREAD_POOL_TASK_FUNC(lnk_push_dbi_sec_contrib_task)
   for (U64 sect_idx = 0; sect_idx < obj->header.section_count_no_null; sect_idx += 1) {
     COFF_SectionHeader *obj_sect_header = &obj_section_table[sect_idx];
 
-    if (obj_sect_header->flags & COFF_SectionFlag_LnkRemove) {
-      continue;
-    }
-    if (lnk_is_coff_section_debug(obj, sect_idx)) {
-      continue;
-    }
+    if (obj_sect_header->flags & COFF_SectionFlag_LnkInfo)    { continue; }
+    if (obj_sect_header->flags & COFF_SectionFlag_LnkRemove)  { continue; }
+    if (obj_sect_header->flags & LNK_SECTION_FLAG_DEBUG_INFO) { continue; }
 
     U64     sect_number;
     String8 sect_data;

--- a/src/linker/lnk_io.h
+++ b/src/linker/lnk_io.h
@@ -28,8 +28,6 @@ shared_function uint64_t lnk_write_file(void *raw_handle, uint64_t offset, void 
 
 // --- IO Functions ------------------------------------------------------------
 
-internal String8List lnk_file_search(Arena *arena, String8List dir_list, String8 file_path);
-
 internal OS_Handle lnk_file_open_with_rename_permissions(String8 path);
 internal B32       lnk_file_set_delete_on_close(OS_Handle handle, B32 delete_file);
 internal B32       lnk_file_rename(OS_Handle handle, String8 new_name);

--- a/src/linker/lnk_lib.c
+++ b/src/linker/lnk_lib.c
@@ -23,8 +23,6 @@ lnk_first_member_sort_key_is_before(void *raw_a, void *raw_b)
 internal B32
 lnk_lib_from_data(Arena *arena, String8 data, String8 path, U64 input_idx, LNK_Lib *lib_out)
 {
-  ProfBeginFunction();
-
   // is data archive?
   COFF_ArchiveType type = coff_archive_type_from_data(data);
   if (type == COFF_Archive_Null) {
@@ -147,7 +145,6 @@ lnk_lib_from_data(Arena *arena, String8 data, String8 path, U64 input_idx, LNK_L
   lib_out->long_names        = parse.long_names;
   lib_out->input_idx         = input_idx;
   
-  ProfEnd();
   return 1;
 }
 

--- a/src/linker/lnk_lib.c
+++ b/src/linker/lnk_lib.c
@@ -112,7 +112,7 @@ lnk_lib_from_data(Arena *arena, String8 data, String8 path, U64 input_idx, LNK_L
       // parse symbol names
       {
         Temp scratch = scratch_begin(&arena, 1);
-        String8List symbol_name_list = str8_split_by_string_chars(scratch.arena, first_member.string_table, str8_lit("\0"), StringSplitFlag_KeepEmpties);
+        String8List symbol_name_list = str8_split_by_string_chars(scratch.arena, first_member.string_table, str8_lit("\0"), 0);
         Assert(symbol_name_list.node_count >= first_member.symbol_count);
         symbol_names = str8_array_from_list(arena, &symbol_name_list);
         scratch_end(scratch);

--- a/src/linker/lnk_obj.c
+++ b/src/linker/lnk_obj.c
@@ -312,8 +312,6 @@ THREAD_POOL_TASK_FUNC(lnk_obj_initer)
   obj->associated_sections     = associated_sections;
   obj->node                    = &task->objs[task_id];
   obj->link_member             = input->link_member;
-
-  ProfEnd();
 }
 
 internal LNK_ObjNode *

--- a/src/linker/lnk_obj.c
+++ b/src/linker/lnk_obj.c
@@ -527,6 +527,12 @@ lnk_coff_string_table_from_obj(LNK_Obj *obj)
   return str8_substr(obj->data, obj->header.string_table_range);
 }
 
+internal String8
+lnk_coff_symbol_table_from_obj(LNK_Obj *obj)
+{
+  return str8_substr(obj->data, obj->header.symbol_table_range);
+}
+
 internal COFF_RelocArray
 lnk_coff_reloc_info_from_section_number(LNK_Obj *obj, U64 section_number)
 {

--- a/src/linker/lnk_obj.h
+++ b/src/linker/lnk_obj.h
@@ -119,6 +119,7 @@ internal COFF_SectionHeader * lnk_coff_section_header_from_section_number(LNK_Ob
 internal COFF_RelocArray      lnk_coff_relocs_from_section_header(LNK_Obj *obj, COFF_SectionHeader *section_header);
 internal COFF_SectionHeader * lnk_coff_section_table_from_obj(LNK_Obj *obj);
 internal String8              lnk_coff_string_table_from_obj(LNK_Obj *obj);
+internal String8              lnk_coff_symbol_table_from_obj(LNK_Obj *obj);
 internal B32                  lnk_try_comdat_props_from_section_number(LNK_Obj *obj, U32 section_number, COFF_ComdatSelectType *select_out, U32 *section_number_out, U32 *section_length_out, U32 *check_sum_out);
 internal B32                  lnk_is_coff_section_debug(LNK_Obj *obj, U64 sect_idx);
 

--- a/src/linker/lnk_obj.h
+++ b/src/linker/lnk_obj.h
@@ -121,7 +121,6 @@ internal COFF_SectionHeader * lnk_coff_section_table_from_obj(LNK_Obj *obj);
 internal String8              lnk_coff_string_table_from_obj(LNK_Obj *obj);
 internal String8              lnk_coff_symbol_table_from_obj(LNK_Obj *obj);
 internal B32                  lnk_try_comdat_props_from_section_number(LNK_Obj *obj, U32 section_number, COFF_ComdatSelectType *select_out, U32 *section_number_out, U32 *section_length_out, U32 *check_sum_out);
-internal B32                  lnk_is_coff_section_debug(LNK_Obj *obj, U64 sect_idx);
 
 // --- Helpers ----------------------------------------------------------------- 
 

--- a/src/linker/lnk_symbol_table.c
+++ b/src/linker/lnk_symbol_table.c
@@ -675,7 +675,7 @@ lnk_resolve_weak_symbol(LNK_SymbolTable *symtab, LNK_ObjSymbolRef symbol, LNK_Ob
           LNK_Symbol *dep_symbol = lnk_symbol_table_search(symtab, tag_parsed.name);
           tag_interp = lnk_interp_from_symbol(dep_symbol);
         }
-        if (tag_interp == COFF_SymbolValueInterp_Weak) { goto exit; }
+        if (tag_interp == COFF_SymbolValueInterp_Weak) { break; }
       }
     } else if (current_interp == COFF_SymbolValueInterp_Undefined) {
       LNK_Symbol                 *defn_symbol = lnk_symbol_table_search(symtab, current_parsed.name);

--- a/src/os/core/win32/os_core_win32.c
+++ b/src/os/core/win32/os_core_win32.c
@@ -1158,6 +1158,7 @@ internal void
 os_mutex_release(Mutex mutex)
 {
   OS_W32_Entity *entity = (OS_W32_Entity*)PtrFromInt(mutex.u64[0]);
+  DeleteCriticalSection(&entity->mutex);
   os_w32_entity_release(entity);
 }
 

--- a/src/os/gfx/win32/os_gfx_win32.c
+++ b/src/os/gfx/win32/os_gfx_win32.c
@@ -507,10 +507,6 @@ os_w32_wnd_proc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
         if(character >= 32 && character != 127)
         {
           OS_Event *event = os_w32_push_event(OS_EventKind_Text, window);
-          if(lParam & bit29)
-          {
-            event->modifiers |= OS_Modifier_Alt;
-          }
           event->character = character;
         }
       }break;

--- a/src/raddbg/raddbg_core.c
+++ b/src/raddbg/raddbg_core.c
@@ -11833,10 +11833,6 @@ rd_frame(void)
         rd_cmd(RD_CmdKind_InsertText, .string = insertion8);
         rd_request_frame();
         take = 1;
-        if(event->modifiers & OS_Modifier_Alt)
-        {
-          ws->menu_bar_focus_press_started = 0;
-        }
       }
       
       //- rjf: do fall-through


### PR DESCRIPTION
One minor arch cracking change, two small win32 fixes. Commit messages should explain details.

I don't believe this project targets ARM platforms right now, and `os_mutex_release` doesn't seem to be called anywhere, so the arch cracking change and the mutex fix shouldn't have a noticeable impact at the moment.

The "ALT key during WM_CHAR events" commit removes dead code and avoids conditionally acting on an lParam bit that is marked as reserved in the win32 docs (empirically appears to always be 0 - so no observable effects).