### PR TITLE
adds missing freetype2/ include path for gcc build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,7 +24,7 @@ clang_debug="$compiler -g -O0 -DBUILD_DEBUG=1 ${clang_common} ${auto_compile_fla
 clang_release="$compiler -g -O2 -DBUILD_DEBUG=0 ${clang_common} ${auto_compile_flags}"
 clang_link="-lpthread -lm -lrt -ldl"
 clang_out="-o"
-gcc_common="-I../src/ -I../local/ -g -DBUILD_GIT_HASH=\"$git_hash\" -DBUILD_GIT_HASH_FULL=\"$git_hash_full\" -Wno-unknown-warning-option -Wall -Wno-missing-braces -Wno-unused-function -Wno-attributes -Wno-unused-value -Wno-unused-variable -Wno-unused-local-typedef -Wno-deprecated-declarations -Wno-unused-but-set-variable -Wno-compare-distinct-pointer-types -D_USE_MATH_DEFINES -Dstrdup=_strdup -Dgnu_printf=printf"
+gcc_common="-I../src/ -I/usr/include/freetype2/ -I../local/ -g -DBUILD_GIT_HASH=\"$git_hash\" -DBUILD_GIT_HASH_FULL=\"$git_hash_full\" -Wno-unknown-warning-option -Wall -Wno-missing-braces -Wno-unused-function -Wno-attributes -Wno-unused-value -Wno-unused-variable -Wno-unused-local-typedef -Wno-deprecated-declarations -Wno-unused-but-set-variable -Wno-compare-distinct-pointer-types -D_USE_MATH_DEFINES -Dstrdup=_strdup -Dgnu_printf=printf"
 gcc_debug="$compiler -g -O0 -DBUILD_DEBUG=1 ${gcc_common} ${auto_compile_flags}"
 gcc_release="$compiler -g -O2 -DBUILD_DEBUG=0 ${gcc_common} ${auto_compile_flags}"
 gcc_link="-lpthread -lm -lrt -ldl"


### PR DESCRIPTION
Building with gcc fails due to missing the freetype2 include path in `build.sh`, which is already available in the `clang_common` var.  

This fix adds "-I/usr/include/freetype2` to the `gcc_common` var, enabled a successful build.

The error is:
```bash
$ build.sh gcc raddbg
...
In file included from ../src/eval/eval_inc.h:7,
                 from ../src/raddbg/raddbg_main.c:254:
../src/eval/eval_core.h:1215:1: warning: multi-line comment [-Wcomment]
 1215 | //        /            /             |                     \
      | ^
In file included from ../src/font_provider/font_provider_inc.h:35,
                 from ../src/raddbg/raddbg_main.c:257:
../src/font_provider/freetype/font_provider_freetype.h:11:10: fatal error: ft2build.h: No such file or dir
   11 | #include <ft2build.h>
      |          ^~~~~~~~~~~~
compilation terminated.
```

With the fix, the build is successful.
