### PR TITLE
Arena reserved size should always add ARENA_HEADER_SIZE

### DIFF
--- a/src/base/base_arena.c
+++ b/src/base/base_arena.c
@@ -10,7 +10,7 @@ internal Arena *
 arena_alloc_(ArenaParams *params)
 {
   // rjf: round up reserve/commit sizes
-  U64 reserve_size = params->reserve_size;
+  U64 reserve_size = params->reserve_size + ARENA_HEADER_SIZE;
   U64 commit_size = params->commit_size;
   if(params->flags & ArenaFlag_LargePages)
   {
@@ -260,3 +260,4 @@ temp_end(Temp temp)
 {
   arena_pop_to(temp.arena, temp.pos);
 }
+


### PR DESCRIPTION
When allocating memory with the arena the reserve size should always incorporate the size of the arena header. Otherwise, it can fail badly in `arena_push()`.

In `arena_push()` on line 101 when checking if a existing free block exists the reserved size of the block is checked to see if the allocation will fit into the free block: `if(new_block->res >= AlignPow2(new_block->pos, align) + size)`.

Little bit further down the `pos_pst` gets adjusted for the new free block:
```
    current = new_block;
    pos_pre = AlignPow2(current->pos, align);
    pos_pst = pos_pre + size;
```
`post_pre` will always be at least `ARENA_HEADER_SIZE` big.

This means the allocation will eventually not fit. The condition `assert(pos_pst < current->res);` always needs to be true. But currently that is not necessary the case.

Note: When allocating new blocks in `arena_push()` the `ARENA_HEADER_SIZE` always gets added to the reserved size as it should be.
