### PR TITLE
better callstack for null calls

### DIFF
--- a/src/os/core/win32/os_core_win32.c
+++ b/src/os/core/win32/os_core_win32.c
@@ -208,7 +208,11 @@ internal B32
 os_commit(void *ptr, U64 size)
 {
   B32 result = (VirtualAlloc(ptr, size, MEM_COMMIT, PAGE_READWRITE) != 0);
-  w32_rio_functions.RIODeregisterBuffer(w32_rio_functions.RIORegisterBuffer(ptr, size));
+  if (w32_rio_functions.RIORegisterBuffer)
+  {
+    // wine does not implement these functions
+    w32_rio_functions.RIODeregisterBuffer(w32_rio_functions.RIORegisterBuffer(ptr, size));
+  }
   return result;
 }
 
@@ -1565,7 +1569,43 @@ win32_exception_filter(EXCEPTION_POINTERS* exception_ptrs)
 #else
 #  error Arch not supported!
 #endif
-          
+
+#if BUILD_CONSOLE_INTERFACE
+          buflen += wnsprintfW(buffer + buflen, ArrayCount(buffer) - buflen, L"\nCreate a new issue with this report at %S.\n\n", BUILD_ISSUES_LINK_STRING_LITERAL);
+#else
+          buflen += wnsprintfW(buffer + buflen, ArrayCount(buffer) - buflen,
+              L"\nPress Ctrl+C to copy this text to clipboard, then create a new issue at\n"
+              L"<a href=\"%S\">%S</a>\n\n", BUILD_ISSUES_LINK_STRING_LITERAL, BUILD_ISSUES_LINK_STRING_LITERAL);
+#endif
+          buflen += wnsprintfW(buffer + buflen, ArrayCount(buffer) - buflen, L"Call stack:\n");
+
+          U64 frame_offset = 0;
+
+          if (frame.AddrPC.Offset == 0)
+          {
+            // if IP address is 0 then most likely we have called indirectly on NULL function pointer
+            // which means no useful stack unwinding will happen, because there's no unwind info for address 0
+            // but we can try reading 8 bytes of return address from stack, and start unwinding there
+
+            ULONG_PTR hi, lo;
+            GetCurrentThreadStackLimits(&lo, &hi);
+            if (frame.AddrStack.Offset >= lo && frame.AddrStack.Offset <= hi - sizeof(void*))
+            {
+              frame.AddrPC.Offset = *(DWORD64*)frame.AddrStack.Offset - 1;
+              frame.AddrStack.Offset += sizeof(void*);
+#if defined(_M_AMD64)
+              context->Rip = frame.AddrPC.Offset;
+              context->Rsp = frame.AddrStack.Offset;
+#elif defined(_M_ARM64)
+              context->Pc = frame.AddrPC.Offset;
+              context->Sp = frame.AddrStack.Offset;
+#endif
+            }
+
+            buflen += wnsprintfW(buffer + buflen, ArrayCount(buffer) - buflen, L"1. [NULL]\n");
+            frame_offset = 1;
+          }
+
           for(U32 idx=0; ;idx++)
           {
             const U32 max_frames = 32;
@@ -1586,19 +1626,7 @@ win32_exception_filter(EXCEPTION_POINTERS* exception_ptrs)
               break;
             }
             
-            if(idx==0)
-            {
-#if BUILD_CONSOLE_INTERFACE
-              buflen += wnsprintfW(buffer + buflen, ArrayCount(buffer) - buflen, L"\nCreate a new issue with this report at %S.\n\n", BUILD_ISSUES_LINK_STRING_LITERAL);
-#else
-              buflen += wnsprintfW(buffer + buflen, ArrayCount(buffer) - buflen,
-                                   L"\nPress Ctrl+C to copy this text to clipboard, then create a new issue at\n"
-                                   L"<a href=\"%S\">%S</a>\n\n", BUILD_ISSUES_LINK_STRING_LITERAL, BUILD_ISSUES_LINK_STRING_LITERAL);
-#endif
-              buflen += wnsprintfW(buffer + buflen, ArrayCount(buffer) - buflen, L"Call stack:\n");
-            }
-            
-            buflen += wnsprintfW(buffer + buflen, ArrayCount(buffer) - buflen, L"%u. [0x%I64x]", idx + 1, address);
+            buflen += wnsprintfW(buffer + buflen, ArrayCount(buffer) - buflen, L"%u. [0x%I64x]", frame_offset + idx + 1, address);
             
             struct {
               SYMBOL_INFOW info;


### PR DESCRIPTION
This improves callstack in win32 unhandled exception handler when indirect call to NULL happens. Before no call stack was printed at all, so it was hard to know what happened. Now call stack explicitly will print out [NULL] stack entry + rest of call stack entries. This is done by manually looking up return address from call stack when possible.

Also fixes wine compatibility for os_commit function. Wine does not support RIO buffer functions.

Before:
```
--- Fatal Exception ---
A fatal exception (code 0xc0000005) occurred. The process is terminating.

Version: 0.9.25 [5b6ffd5a-dirty]
```

After:
```
--- Fatal Exception ---
A fatal exception (code 0xc0000005) occurred. The process is terminating.

Create a new issue with this report at https://github.com/EpicGamesExt/raddebugger/issues.

Call stack:
1. [NULL]
2. [0x1400defb7] os_commit +87, os_core_win32.c line 214
3. [0x1400d5d2d] arena_alloc_ +397, base_arena.c line 38
4. [0x14013ac32] w32_entry_point_caller +882, os_core_win32.c line 1786
5. [0x14013b64b] wmain +27, os_core_win32.c line 1888
6. [0x140248fc0] __scrt_common_main_seh +268, exe_common.inl line 288
7. [0x6fffffa31469] kernel32
8. [0x6fffffc10d2b] ntdll

Version: 0.9.25 [98c90720-dirty]
```