### PR TITLE
Fixed some issues with the evaluation of casts

### DIFF
--- a/src/eval/eval_ir.c
+++ b/src/eval/eval_ir.c
@@ -890,11 +890,10 @@ e_push_irtree_and_type_from_expr(Arena *arena, E_IRTreeAndType *root_parent, E_I
           {
             new_tree = e_irtree_convert_lo(arena, in_tree, out_group, in_group);
           }
-          if(cast_type_byte_size < casted_type_byte_size && e_type_kind_is_integer(cast_type_unwrapped_kind))
-          {
-            new_tree = e_irtree_trunc(arena, in_tree, cast_type);
-          }
-          if(e_type_kind_is_signed(cast_type_unwrapped_kind) && e_type_kind_is_integer(casted_type_unwrapped_kind) && !e_type_kind_is_signed(casted_type_unwrapped_kind))
+          else if(cast_type_byte_size < casted_type_byte_size && (
+           e_type_kind_is_integer(cast_type_unwrapped_kind) ||
+          ( e_type_kind_is_signed(cast_type_unwrapped_kind) && e_type_kind_is_integer(casted_type_unwrapped_kind) && !e_type_kind_is_signed(casted_type_unwrapped_kind))
+          ))
           {
             new_tree = e_irtree_trunc(arena, in_tree, cast_type);
           }
@@ -1518,11 +1517,10 @@ e_push_irtree_and_type_from_expr(Arena *arena, E_IRTreeAndType *root_parent, E_I
             {
               new_tree = e_irtree_convert_lo(arena, in_tree, out_group, in_group);
             }
-            if(cast_type_byte_size < casted_type_byte_size && e_type_kind_is_integer(cast_type_unwrapped_kind))
-            {
-              new_tree = e_irtree_trunc(arena, in_tree, cast_type);
-            }
-            if(e_type_kind_is_signed(cast_type_unwrapped_kind) && e_type_kind_is_integer(casted_type_unwrapped_kind) && !e_type_kind_is_signed(casted_type_unwrapped_kind))
+            else if(cast_type_byte_size < casted_type_byte_size && (
+             e_type_kind_is_integer(cast_type_unwrapped_kind) ||
+            ( e_type_kind_is_signed(cast_type_unwrapped_kind) && e_type_kind_is_integer(casted_type_unwrapped_kind) && !e_type_kind_is_signed(casted_type_unwrapped_kind))
+            ))
             {
               new_tree = e_irtree_trunc(arena, in_tree, cast_type);
             }


### PR DESCRIPTION
There are a few issues when parsing cast operations in the watch window. Most notably casting to a signed 64bit integer would truncate the full value:
<img width="536" height="376" alt="cast_bug" src="https://github.com/user-attachments/assets/d428d109-6060-44d3-9f23-0773170c5a5f" />
Not sure if this is an appropriate way to fix it and there seems to be no operation to sign extend values so this is not complete.
For example these expressions still yield different values after the fix:
hex( (s64) ( (s32) 0xff223344ff667788 ) ) =  0xff667788
hex( (s64)   (s32) 0xff223344ff667788   ) = -0x998878
