### PR TITLE
Fix Linux debugging on NVIDIA + X11

### DIFF
--- a/src/dbg_info/dbg_info.c
+++ b/src/dbg_info/dbg_info.c
@@ -746,7 +746,48 @@ di_async_tick(void)
           }
           else
           {
-            rdi_path = str8f(scratch.arena, "%S.rdi", str8_chop_last_dot(og_path));
+            // by default, write rdi next to original. but if original lives in
+            // a typically read-only system location, redirect to user cache dir.
+            B32 use_user_cache = 0;
+#if OS_LINUX
+            local_persist read_only String8 system_prefixes[] =
+            {
+              str8_lit_comp("/usr/"),
+              str8_lit_comp("/lib/"),
+              str8_lit_comp("/lib64/"),
+              str8_lit_comp("/lib32/"),
+              str8_lit_comp("/opt/"),
+              str8_lit_comp("/bin/"),
+              str8_lit_comp("/sbin/"),
+              str8_lit_comp("/etc/"),
+            };
+            for EachElement(idx, system_prefixes)
+            {
+              if(str8_match(str8_prefix(og_path, system_prefixes[idx].size), system_prefixes[idx], 0))
+              {
+                use_user_cache = 1;
+                break;
+              }
+            }
+#endif
+            if(use_user_cache)
+            {
+              String8 user_data = get_process_info()->user_program_cache_data_path;
+              String8 cache_dir = push_str8f(scratch.arena, "%S/raddbg/rdi-cache", user_data);
+              make_directory(cache_dir);
+              Temp esc_scratch = temp_begin(scratch.arena);
+              String8 escaped = push_str8_copy(esc_scratch.arena, og_path);
+              for(U64 i = 0; i < escaped.size; i += 1)
+              {
+                if(escaped.str[i] == '/') { escaped.str[i] = '_'; }
+              }
+              rdi_path = push_str8f(scratch.arena, "%S/%S.rdi", cache_dir, str8_chop_last_dot(escaped));
+              temp_end(esc_scratch);
+            }
+            else
+            {
+              rdi_path = str8f(scratch.arena, "%S.rdi", str8_chop_last_dot(og_path));
+            }
           }
         }
         

--- a/src/rdi_from_dwarf/rdi_from_dwarf.c
+++ b/src/rdi_from_dwarf/rdi_from_dwarf.c
@@ -430,7 +430,16 @@ d2r_convert(Arena *arena, D2R_ConvertParams *params)
       {
         DW2_LineTableFile *f = &hdr->files.v[file_idx];
         DW2_LineTableFile *dir = &hdr->dirs.v[f->dir_idx];
-        String8 full_file_path = str8f(scratch2.arena, "%S%s%S", dir->file_name, dir->file_name.size != 0 ? "/" : "", f->file_name);
+        // DWARFv5 sec 6.2.4 -- dir index 0 is the compilation directory; other dir
+        // entries may be relative to it. prepend dir 0 when the chosen dir is non-zero and
+        // relative, so module-relative source paths resolve correctly.
+        String8 comp_dir = hdr->dirs.count != 0 ? hdr->dirs.v[0].file_name : str8_zero();
+        PathStyle dir_style = path_style_from_str8(dir->file_name);
+        B32 dir_is_relative = (dir_style == PathStyle_Null || dir_style == PathStyle_Relative);
+        B32 prepend_comp_dir = (f->dir_idx != 0 && dir_is_relative && comp_dir.size != 0);
+        String8 full_file_path = prepend_comp_dir ?
+          str8f(scratch2.arena, "%S/%S%s%S", comp_dir, dir->file_name, dir->file_name.size != 0 ? "/" : "", f->file_name) :
+          str8f(scratch2.arena, "%S%s%S", dir->file_name, dir->file_name.size != 0 ? "/" : "", f->file_name);
         U64 hash = u64_hash_from_str8(full_file_path);
         U64 slot_idx = hash%slots_count;
         SrcFileNode *node = 0;


### PR DESCRIPTION
Hit several issues debugging on Arch + NVIDIA 595 + X11.

X11 window used CopyFromParent visual, mismatching EGL/GLX framebuffer config: GLX BadMatch crash, EGL silent black window. Renderer now publishes its chosen visual + colormap.

eglCreateContext got a null EGLConfig; NVIDIA lacks EGL_KHR_no_config_context, so the context silently no-op'd and all draws hit GL_INVALID_OPERATION. Pass the config; bind a pbuffer at init.

dmn_lnx_rdebug_vaddr_from_memory SIGILL'd on the GNU_HASH branch (NotImplemented). Modern toolchains link --hash-style=gnu only. Symbol count now derived from GNU_HASH.

Breakpoints didn't bind: rdi_from_dwarf built source paths from `dir_table[dir_idx]` + file->path without prepending `dir_table[0]`, so build/main.c became /build/main.c. DWARFv5 6.2.4: relative dir entries append to entry 0.

Memory view SIGILL'd on unimplemented eval ops at -Og/-O2. Implemented Swap; soft-fail BadOp for CallSiteValue (entry_value needs caller-frame regs, not plumbed); no-op for piece markers.

RDI cache redirected to ~/raddbg/rdi-cache when the binary lives under /usr, /lib, etc. - writes for libc.so/ld.so were failing.

GLX rendered a black window: NVIDIA leaves GL_DRAW_BUFFER at GL_NONE when the context is first made current with no drawable, and switching to a real drawable later doesn't reset it. All clears/draws to the default framebuffer were silently dropped. Set GL_DRAW_BUFFER=GL_BACK after each glXMakeCurrent.

EGL backend cast the outer R_Handle directly to R_OGL_LNX_Window*, but after the R_OGL_Window wrapper landed it points at R_OGL_Window*. eglMakeCurrent/eglSwapBuffers got garbage surfaces. Unwrap the wrapper, then read .os.

Tested on ArchLinux + NVIDIA 595.58.03 + X11(dwm). Not tested on Mesa or Wayland.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/8afd4662-6315-4629-af65-ea30f368e06c" />
