### PR TITLE
Fix accidental busy-waiting in `async_thread_entry_point` on Linux

### DIFF
--- a/src/linux/base/linux_base.c
+++ b/src/linux/base/linux_base.c
@@ -485,7 +485,11 @@ internal CondVar
 cond_var_alloc(void)
 {
   LNX_Entity *entity = lnx_entity_alloc(LNX_EntityKind_ConditionVariable);
-  int init_result = pthread_cond_init(&entity->cv.cond_handle, 0);
+  pthread_condattr_t attr;
+  pthread_condattr_init(&attr);
+  pthread_condattr_setclock(&attr, CLOCK_MONOTONIC);
+  int init_result = pthread_cond_init(&entity->cv.cond_handle, &attr);
+  pthread_condattr_destroy(&attr);
   if(init_result == -1)
   {
     lnx_entity_release(entity);


### PR DESCRIPTION
The commit fixes unintentional busy-waiting in `async_thread_entry_point` on Linux by initializing condition variables with `CLOCK_MONOTONIC`. By default, condition variables on Linux (glibc/musl) are initialized with `CLOCK_REALTIME`, while `now_time_us` uses `CLOCK_MONOTONIC`.  This clock mismatch causes the call to `pthread_cond_timedwait` in `cond_var_wait` to return immediately instead of waiting for work. As a result, the async threads consume significant CPU time while doing nothing (e.g. on my laptop, all 22 logical cores at roughly 40% just from having the debugger open).

(edit) Noticed that this may fix #765

---

**Additional Details**
Passing `0` as the `pthread_condattr_t` argument to `pthread_cond_init` in `cond_var_alloc` will initialize the condition variable with [default attributes](https://pubs.opengroup.org/onlinepubs/9799919799/functions/pthread_cond_init.html).  At least the [glibc](https://sourceware.org/git/?p=glibc.git;a=blob;f=nptl/pthread_cond_init.c;h=688bcae5de5a6d0ecad2115ac486891961e2854a;hb=HEAD#l40) and [musl](https://github.com/kraj/musl/blob/kraj/master/src/thread/pthread_cond_init.c#L6) implementations will in this case initialize the clock attribute of the condition variable to `CLOCK_REALTIME` (`0`), whose reference point for the values in `timespec` is the Unix epoch when calling [clock_gettime](https://pubs.opengroup.org/onlinepubs/9799919799/functions/clock_gettime.html).

In `now_time_us`, the current time is computed using `clock_gettime(CLOCK_MONOTONIC, &t)` which will fill the `timespec` structure fields with the reference point on Linux being [system boot time](https://man7.org/linux/man-pages/man3/clock_gettime.3.html#top_of_page:~:text=International%20Atomic%20Time.-,CLOCK_MONOTONIC,-A%20nonsettable%20system).

`pthread_cond_timedwait` will use the condition variable's configured clock, `CLOCK_REALTIME`, to tell the kernel in the futex system call which clock to use. Since a monotonic timestamp (seconds since boot) is much smaller than a realtime timestamp (seconds since 1970), the deadline is always already in the past. The call returns `ETIMEDOUT` immediately without ever sleeping.