### PR TITLE
Fix rdi_decompressed_size_from_parsed to account for 8-byte alignment padding

### DIFF
--- a/src/lib_rdi/rdi_parse.c
+++ b/src/lib_rdi/rdi_parse.c
@@ -276,12 +276,17 @@ rdi_section_raw_element_from_kind_idx(RDI_Parsed *rdi, RDI_SectionKind kind, RDI
 RDI_PROC RDI_U64
 rdi_decompressed_size_from_parsed(RDI_Parsed *rdi)
 {
-  RDI_U64 decompressed_size = rdi->raw_data_size;
+  RDI_Header *hdr = (RDI_Header *)rdi->raw_data;
+  U64 off = hdr->data_section_off + sizeof(RDI_Section) * rdi->sections_count;
+  off += 7;
+  off -= off%8;
   for(RDI_U64 section_idx = 0; section_idx < rdi->sections_count; section_idx += 1)
   {
-    decompressed_size += (rdi->sections[section_idx].unpacked_size - rdi->sections[section_idx].encoded_size);
+    off += rdi->sections[section_idx].unpacked_size;
+    off += 7;
+    off -= off%8;
   }
-  return decompressed_size;
+  return off;
 }
 
 //- decompression


### PR DESCRIPTION
## Bug

`rdi_decompressed_size_from_parsed` computes the decompressed size as:

```c
decompressed_size = raw_data_size + sum(unpacked_size - encoded_size)
```

This formula assumes sections are packed tightly in the decompressed buffer. However, `rdi_decompress_parsed` aligns each section's data to 8-byte boundaries with padding, so the actual decompressed buffer is larger than the formula predicts. When callers (radbin.c, dbg_info.c) use this function to allocate the output buffer, the buffer may be too small, causing a heap buffer overflow.

## Fix

Replicate the exact layout computation from `rdi_decompress_parsed` to compute the correct decompressed size:

```c
off = data_section_off + sizeof(RDI_Section) * sections_count;
off = align_up(off, 8);
for each section:
    off += section.unpacked_size;
    off = align_up(off, 8);
return off;
```