### PR TITLE
Fix file/directory table count in pre-DWARF5 line table parsing

### DIFF
--- a/src/dwarf/dwarf_parse_2.c
+++ b/src/dwarf/dwarf_parse_2.c
@@ -720,7 +720,8 @@ dw2_read_line_table_header(Arena *arena, DW2_ParseCtx *ctx, String8 data, U64 of
       //- rjf: gather directories
       DW2_LineTableFileList dir_list = {0};
       {
-        // rjf: push compile directory as first list element, always
+        // rjf: push compile directory as first list element, if available
+        if(ctx->unit_dir.size != 0)
         {
           DW2_LineTableFileNode *n = push_array(scratch.arena, DW2_LineTableFileNode, 1);
           SLLQueuePush(dir_list.first, dir_list.last, n);
@@ -750,7 +751,8 @@ dw2_read_line_table_header(Arena *arena, DW2_ParseCtx *ctx, String8 data, U64 of
       //- rjf: gather files
       DW2_LineTableFileList file_list = {0};
       {
-        // rjf: push main compilation unit file as first list element, always
+        // rjf: push main compilation unit file as first list element, if available
+        if(ctx->unit_file.size != 0)
         {
           DW2_LineTableFileNode *n = push_array(scratch.arena, DW2_LineTableFileNode, 1);
           SLLQueuePush(file_list.first, file_list.last, n);

--- a/src/rdi_from_dwarf/rdi_from_dwarf_2.c
+++ b/src/rdi_from_dwarf/rdi_from_dwarf_2.c
@@ -839,7 +839,7 @@ d2r2_convert(Arena *arena, D2R2_ConvertParams *params)
       //- rjf: set up vm registers
       DW2_LineVMRegs vm_regs = {0};
       {
-        vm_regs.file_index = 1;
+        vm_regs.file_index = (line_table_header->version < DW_Version_5 ? 1 : 0);
         vm_regs.line = 1;
         vm_regs.is_stmt = line_table_header->default_is_stmt;
       }
@@ -1035,9 +1035,28 @@ d2r2_convert(Arena *arena, D2R2_ConvertParams *params)
         
         //- rjf: map file index -> rdim src file
         RDIM_SrcFile *src_file = 0;
-        if(vm_regs.file_index < line_table_header->files.count)
         {
-          src_file = unit_src_file_maps[unit_idx].v[vm_regs.file_index];
+          B32 valid_file = 0;
+          U64 file_array_idx = vm_regs.file_index;
+          if(line_table_header->version < DW_Version_5)
+          {
+            if(vm_regs.file_index >= 1 && vm_regs.file_index <= line_table_header->files.count)
+            {
+              valid_file = 1;
+              file_array_idx = vm_regs.file_index - 1;
+            }
+          }
+          else
+          {
+            if(vm_regs.file_index < line_table_header->files.count)
+            {
+              valid_file = 1;
+            }
+          }
+          if(valid_file)
+          {
+            src_file = unit_src_file_maps[unit_idx].v[file_array_idx];
+          }
         }
         
         //- rjf: sequence ended explicitly, or file change, or end of stream? -> push to line table


### PR DESCRIPTION
## Bug

`ctx->unit_dir` and `ctx->unit_file` in `DW2_ParseCtx` are never populated by the caller (`rdi_from_dwarf_2.c`), but `dw2_read_line_table_header` unconditionally pushed them as the first directory and file entries for pre-DWARF5 line tables. This created an empty leading entry, making `dirs.count` and `files.count` one greater than the actual data.

Additionally, `DW_StdOpcode_File` in the line VM sets `file_index` to 1-based values for pre-DWARF5 and 0-based for DWARF 5, but the array lookup used the raw 1-based index directly on a 0-based array, and the initial `file_index` was unconditionally set to 1 (wrong for DWARF 5 where it should be 0).

## Changes

**`src/dwarf/dwarf_parse_2.c`**: Guard the first-entry pushes behind `size != 0` checks so the DWARF data's own entries stand on their own when the context fields are unpopulated.

**`src/rdi_from_dwarf/rdi_from_dwarf_2.c`**:
- Initialize `file_index` to 0 for DWARF 5, 1 for pre-DWARF5
- Convert 1-based file indices to 0-based array indices for pre-DWARF5 in the source file lookup
- Fix the bounds check for each DWARF version's indexing scheme