### PR TITLE
Use multiply to calculate hashtable index faster

### DIFF
--- a/src/artifact_cache/artifact_cache.c
+++ b/src/artifact_cache/artifact_cache.c
@@ -35,7 +35,7 @@ ac_artifact_from_key_(Access *access, String8 key, AC_ArtifactParams *params, U6
   AC_Cache *cache = 0;
   {
     U64 cache_hash = u64_hash_from_str8(str8_struct(&params->create));
-    U64 cache_slot_idx = cache_hash%ac_shared->cache_slots_count;
+    U64 cache_slot_idx = hash_index64(cache_hash, ac_shared->cache_slots_count);
     Stripe *cache_stripe = stripe_from_slot_idx(&ac_shared->cache_stripes, cache_slot_idx);
     for(B32 write_mode = 0; write_mode <= 1; write_mode += 1)
     {
@@ -70,7 +70,7 @@ ac_artifact_from_key_(Access *access, String8 key, AC_ArtifactParams *params, U6
   
   //- rjf: unpack key
   U64 hash = u64_hash_from_str8(key);
-  U64 slot_idx = hash%cache->slots_count;
+  U64 slot_idx = hash_index64(hash, cache->slots_count);
   AC_Slot *slot = &cache->slots[slot_idx];
   Stripe *stripe = stripe_from_slot_idx(&cache->stripes, slot_idx);
   
@@ -415,7 +415,7 @@ ac_async_tick(void)
         if(status != AC_Status_NeedRetry && lane_idx() == 0)
         {
           U64 cache_hash = u64_hash_from_str8(str8_struct(&r->create));
-          U64 cache_slot_idx = cache_hash%ac_shared->cache_slots_count;
+          U64 cache_slot_idx = hash_index64(cache_hash, ac_shared->cache_slots_count);
           Stripe *cache_stripe = stripe_from_slot_idx(&ac_shared->cache_stripes, cache_slot_idx);
           RWMutexScope(cache_stripe->rw_mutex, 0)
           {
@@ -434,7 +434,7 @@ ac_async_tick(void)
         if(status != AC_Status_NeedRetry && lane_idx() == 0)
         {
           U64 hash = u64_hash_from_str8(r->key);
-          U64 slot_idx = hash%cache->slots_count;
+          U64 slot_idx = hash_index64(hash, cache->slots_count);
           AC_Slot *slot = &cache->slots[slot_idx];
           Stripe *stripe = stripe_from_slot_idx(&cache->stripes, slot_idx);
           RWMutexScope(stripe->rw_mutex, 1)
@@ -542,7 +542,7 @@ ac_async_tick(void)
         if(status != AC_Status_NeedRetry)
         {
           U64 cache_hash = u64_hash_from_str8(str8_struct(&r->create));
-          U64 cache_slot_idx = cache_hash%ac_shared->cache_slots_count;
+          U64 cache_slot_idx = hash_index64(cache_hash, ac_shared->cache_slots_count);
           Stripe *cache_stripe = stripe_from_slot_idx(&ac_shared->cache_stripes, cache_slot_idx);
           RWMutexScope(cache_stripe->rw_mutex, 0)
           {
@@ -561,7 +561,7 @@ ac_async_tick(void)
         if(status != AC_Status_NeedRetry)
         {
           U64 hash = u64_hash_from_str8(r->key);
-          U64 slot_idx = hash%cache->slots_count;
+          U64 slot_idx = hash_index64(hash, cache->slots_count);
           AC_Slot *slot = &cache->slots[slot_idx];
           Stripe *stripe = stripe_from_slot_idx(&cache->stripes, slot_idx);
           RWMutexScope(stripe->rw_mutex, 1)

--- a/src/base/base_command_line.c
+++ b/src/base/base_command_line.c
@@ -11,7 +11,7 @@ cmd_line_slot_from_string(CmdLine *cmd_line, String8 string)
   if(cmd_line->option_table_size != 0)
   {
     U64 hash = u64_hash_from_str8(string);
-    U64 bucket = hash % cmd_line->option_table_size;
+    U64 bucket = hash_index64(hash, cmd_line->option_table_size);
     slot = &cmd_line->option_table[bucket];
   }
   return slot;

--- a/src/base/base_core.c
+++ b/src/base/base_core.c
@@ -744,6 +744,34 @@ count_digits_u64(U64 v, U64 radix)
 }
 
 ////////////////////////////////
+
+internal U32
+hash_index32(U32 hash, U32 count)
+{
+    U32 result = 0;
+#if COMPILER_MSVC && ARCH_X64
+    result = __emulu(hash, count) >> 32;
+#else
+    result = ((U64)hash * count) >> 32;
+#endif
+    return result;
+}
+
+internal U64
+hash_index64(U64 hash, U64 count)
+{
+    U64 result = 0;
+#if COMPILER_MSVC && ARCH_X64
+    (void)_umul128(hash, count, &result);
+#elif COMPILER_MSVC && ARCH_ARM64
+    result = __umulh(hash, count);
+#else
+    result = ((unsigned __int128)hash * count) >> 64;
+#endif
+    return result;
+}
+
+////////////////////////////////
 //~ rjf: Third Party Includes
 
 #if !BUILD_SUPPLEMENTARY_UNIT

--- a/src/base/base_core.h
+++ b/src/base/base_core.h
@@ -1132,4 +1132,12 @@ internal U64 index_of_zero_u32(U32 *ptr, U64 count);
 internal U64 index_of_zero_u64(U64 *ptr, U64 count);
 internal U64 count_digits_u64(U64 v, U64 radix);
 
+////////////////////////////////
+// maps uniform random 32-bit or 64-bit hash value to [0, count) interval
+// this is similar to "hash % count" operation, except it is much faster
+// be aware it will calculate different result than % operation!
+
+internal U32 hash_index32(U32 hash, U32 count);
+internal U64 hash_index64(U64 hash, U64 count);
+
 #endif // BASE_CORE_H

--- a/src/config/config_bindings.c
+++ b/src/config/config_bindings.c
@@ -52,8 +52,8 @@ cfg_key_map_from_cfg(Arena *arena)
         {
           U64 name_hash = d_hash_from_string(name);
           U64 binding_hash = d_hash_from_string(str8_struct(&binding));
-          U64 name_slot_idx = name_hash%key_map->name_slots_count;
-          U64 binding_slot_idx = binding_hash%key_map->binding_slots_count;
+          U64 name_slot_idx = hash_index64(name_hash, key_map->name_slots_count);
+          U64 binding_slot_idx = hash_index64(binding_hash, key_map->binding_slots_count);
           CFG_KeyMapNode *n = push_array(arena, CFG_KeyMapNode, 1);
           n->cfg_id = keybinding->id;
           n->name = push_str8_copy(arena, name);
@@ -74,7 +74,7 @@ cfg_key_map_node_ptr_list_from_name(Arena *arena, CFG_KeyMap *key_map, String8 s
   CFG_KeyMapNodePtrList list = {0};
   {
     U64 hash = d_hash_from_string(string);
-    U64 slot_idx = hash%key_map->name_slots_count;
+    U64 slot_idx = hash_index64(hash, key_map->name_slots_count);
     for(CFG_KeyMapNode *n = key_map->name_slots[slot_idx].first; n != 0; n = n->name_hash_next)
     {
       if(str8_match(n->name, string, 0))
@@ -95,7 +95,7 @@ cfg_key_map_node_ptr_list_from_binding(Arena *arena, CFG_KeyMap *key_map, CFG_Bi
   CFG_KeyMapNodePtrList list = {0};
   {
     U64 hash = d_hash_from_string(str8_struct(&binding));
-    U64 slot_idx = hash%key_map->binding_slots_count;
+    U64 slot_idx = hash_index64(hash, key_map->binding_slots_count);
     for(CFG_KeyMapNode *n = key_map->binding_slots[slot_idx].first; n != 0; n = n->binding_hash_next)
     {
       if(MemoryMatchStruct(&binding, &n->binding))

--- a/src/config/config_core.c
+++ b/src/config/config_core.c
@@ -69,7 +69,7 @@ internal void
 cfg_schema_table_insert(Arena *arena, CFG_SchemaTable *table, String8 name, MD_Node *schema)
 {
   U64 hash = u64_hash_from_str8(name);
-  U64 slot_idx = hash%table->slots_count;
+  U64 slot_idx = hash_index64(hash, table->slots_count);
   CFG_SchemaNode *node = 0;
   for(CFG_SchemaNode *n = table->slots[slot_idx]; n != 0; n = n->next)
   {
@@ -94,7 +94,7 @@ cfg_schema_from_name(CFG_SchemaTable *table, String8 name)
   MD_Node *result = &md_nil_node;
   {
     U64 hash = u64_hash_from_str8(name);
-    U64 slot_idx = hash%table->slots_count;
+    U64 slot_idx = hash_index64(hash, table->slots_count);
     CFG_SchemaNode *node = 0;
     for(CFG_SchemaNode *n = table->slots[slot_idx]; n != 0; n = n->next)
     {
@@ -185,7 +185,7 @@ cfg_node_from_id(CFG_ID id)
   else
   {
     U64 hash = u64_hash_from_str8(str8_struct(&id));
-    U64 slot_idx = hash%cfg_ctx->id_slots_count;
+    U64 slot_idx = hash_index64(hash, cfg_ctx->id_slots_count);
     for(CFG_NodePtrNode *n = cfg_ctx->id_slots[slot_idx].first; n != 0; n = n->next)
     {
       if(n->v->id == id)
@@ -620,7 +620,7 @@ cfg_node_alloc(CFG_State *state)
       cfg_id_node = push_array(state->arena, CFG_NodePtrNode, 1);
     }
     U64 hash = u64_hash_from_str8(str8_struct(&result->id));
-    U64 slot_idx = hash%state->ctx.id_slots_count;
+    U64 slot_idx = hash_index64(hash, state->ctx.id_slots_count);
     DLLPushBack(state->ctx.id_slots[slot_idx].first, state->ctx.id_slots[slot_idx].last, cfg_id_node);
     cfg_id_node->v = result;
   }
@@ -650,7 +650,7 @@ cfg_node_release(CFG_State *state, CFG_Node *node)
   {
     CFG_Node *c = n->v;
     U64 hash = u64_hash_from_str8(str8_struct(&c->id));
-    U64 slot_idx = hash%state->ctx.id_slots_count;
+    U64 slot_idx = hash_index64(hash, state->ctx.id_slots_count);
     cfg_string_release(state, c->string);
     SLLStackPush(state->free, c);
     c->first = c->last = c->prev = c->parent = 0;

--- a/src/content/content.c
+++ b/src/content/content.c
@@ -160,14 +160,14 @@ c_submit_data(C_Key key, Arena **data_arena, String8 data)
 {
   //- rjf: unpack key
   U64 key_hash = u64_hash_from_str8(str8_struct(&key));
-  U64 key_slot_idx = key_hash%c_shared->key_slots_count;
+  U64 key_slot_idx = hash_index64(key_hash, c_shared->key_slots_count);
   U64 key_stripe_idx = key_slot_idx%c_shared->key_stripes_count;
   C_KeySlot *key_slot = &c_shared->key_slots[key_slot_idx];
   C_Stripe *key_stripe = &c_shared->key_stripes[key_stripe_idx];
   
   //- rjf: hash data, unpack hash
   U128 hash = u128_hash_from_str8(data);
-  U64 slot_idx = hash.u64[1]%c_shared->blob_slots_count;
+  U64 slot_idx = hash_index64(hash.u64[1], c_shared->blob_slots_count);
   U64 stripe_idx = slot_idx%c_shared->blob_stripes_count;
   C_BlobSlot *slot = &c_shared->blob_slots[slot_idx];
   C_Stripe *stripe = &c_shared->blob_stripes[stripe_idx];
@@ -273,7 +273,7 @@ c_submit_data(C_Key key, Arena **data_arena, String8 data)
     if(key_is_new)
     {
       U64 root_hash = u64_hash_from_str8(str8_struct(&key.root));
-      U64 root_slot_idx = root_hash%c_shared->root_slots_count;
+      U64 root_slot_idx = hash_index64(root_hash, c_shared->root_slots_count);
       U64 root_stripe_idx = root_slot_idx%c_shared->root_stripes_count;
       C_RootSlot *root_slot = &c_shared->root_slots[root_slot_idx];
       C_Stripe *root_stripe = &c_shared->root_stripes[root_stripe_idx];
@@ -305,7 +305,7 @@ c_submit_data(C_Key key, Arena **data_arena, String8 data)
   //- rjf: decrement key ref count of expired hash
   if(!u128_match(key_expired_hash, u128_zero())) ProfScope("decrement key ref count of expired hash")
   {
-    U64 old_hash_slot_idx = key_expired_hash.u64[1]%c_shared->blob_slots_count;
+    U64 old_hash_slot_idx = hash_index64(key_expired_hash.u64[1], c_shared->blob_slots_count);
     U64 old_hash_stripe_idx = old_hash_slot_idx%c_shared->blob_stripes_count;
     C_BlobSlot *old_hash_slot = &c_shared->blob_slots[old_hash_slot_idx];
     C_Stripe *old_hash_stripe = &c_shared->blob_stripes[old_hash_stripe_idx];
@@ -332,7 +332,7 @@ internal void
 c_close_key(C_Key key)
 {
   U64 key_hash = u64_hash_from_str8(str8_struct(&key));
-  U64 key_slot_idx = key_hash%c_shared->key_slots_count;
+  U64 key_slot_idx = hash_index64(key_hash, c_shared->key_slots_count);
   U64 key_stripe_idx = key_slot_idx%c_shared->key_stripes_count;
   C_KeySlot *key_slot = &c_shared->key_slots[key_slot_idx];
   C_Stripe *key_stripe = &c_shared->key_stripes[key_stripe_idx];
@@ -347,7 +347,7 @@ c_close_key(C_Key key)
             history_idx += 1)
         {
           U128 hash = n->hash_history[(n->hash_history_gen-1-history_idx) % ArrayCount(n->hash_history)];
-          U64 hash_slot_idx = hash.u64[1]%c_shared->blob_slots_count;
+          U64 hash_slot_idx = hash_index64(hash.u64[1], c_shared->blob_slots_count);
           U64 hash_stripe_idx = hash_slot_idx%c_shared->blob_stripes_count;
           C_BlobSlot *hash_slot = &c_shared->blob_slots[hash_slot_idx];
           C_Stripe *hash_stripe = &c_shared->blob_stripes[hash_stripe_idx];
@@ -377,7 +377,7 @@ c_close_key(C_Key key)
 internal void
 c_hash_downstream_inc(U128 hash)
 {
-  U64 slot_idx = hash.u64[1]%c_shared->blob_slots_count;
+  U64 slot_idx = hash_index64(hash.u64[1], c_shared->blob_slots_count);
   U64 stripe_idx = slot_idx%c_shared->blob_stripes_count;
   C_BlobSlot *slot = &c_shared->blob_slots[slot_idx];
   C_Stripe *stripe = &c_shared->blob_stripes[stripe_idx];
@@ -397,7 +397,7 @@ c_hash_downstream_inc(U128 hash)
 internal void
 c_hash_downstream_dec(U128 hash)
 {
-  U64 slot_idx = hash.u64[1]%c_shared->blob_slots_count;
+  U64 slot_idx = hash_index64(hash.u64[1], c_shared->blob_slots_count);
   U64 stripe_idx = slot_idx%c_shared->blob_stripes_count;
   C_BlobSlot *slot = &c_shared->blob_slots[slot_idx];
   C_Stripe *stripe = &c_shared->blob_stripes[stripe_idx];
@@ -422,7 +422,7 @@ c_hash_from_key(C_Key key, U64 rewind_count)
 {
   U128 result = {0};
   U64 key_hash = u64_hash_from_str8(str8_struct(&key));
-  U64 key_slot_idx = key_hash%c_shared->key_slots_count;
+  U64 key_slot_idx = hash_index64(key_hash, c_shared->key_slots_count);
   U64 key_stripe_idx = key_slot_idx%c_shared->key_stripes_count;
   C_KeySlot *key_slot = &c_shared->key_slots[key_slot_idx];
   C_Stripe *key_stripe = &c_shared->key_stripes[key_stripe_idx];
@@ -445,7 +445,7 @@ c_data_from_hash(Access *access, U128 hash)
 {
   ProfBeginFunction();
   String8 result = {0};
-  U64 slot_idx = hash.u64[1]%c_shared->blob_slots_count;
+  U64 slot_idx = hash_index64(hash.u64[1], c_shared->blob_slots_count);
   U64 stripe_idx = slot_idx%c_shared->blob_stripes_count;
   C_BlobSlot *slot = &c_shared->blob_slots[slot_idx];
   C_Stripe *stripe = &c_shared->blob_stripes[stripe_idx];

--- a/src/dbg_engine/dbg_engine_ctrl.c
+++ b/src/dbg_engine/dbg_engine_ctrl.c
@@ -740,7 +740,7 @@ d_entity_from_handle(D_Handle handle)
   if(!d_handle_match(handle, d_handle_zero()))
   {
     U64 hash = d_hash_from_handle(handle);
-    U64 slot_idx = hash%d_entity_ctx->hash_slots_count;
+    U64 slot_idx = hash_index64(hash, d_entity_ctx->hash_slots_count);
     D_EntityHashSlot *slot = &d_entity_ctx->hash_slots[slot_idx];
     D_EntityHashNode *node = 0;
     for(D_EntityHashNode *n = slot->first; n != 0; n = n->next)
@@ -1059,7 +1059,7 @@ d_entity_alloc(D_EntityCtxRWStore *store, D_Entity *parent, D_EntityKind kind, A
     // rjf: insert into hash map
     {
       U64 hash = d_hash_from_handle(handle);
-      U64 slot_idx = hash%store->ctx.hash_slots_count;
+      U64 slot_idx = hash_index64(hash, store->ctx.hash_slots_count);
       D_EntityHashSlot *slot = &store->ctx.hash_slots[slot_idx];
       D_EntityHashNode *node = 0;
       for(D_EntityHashNode *n = slot->first; n != 0; n = n->next)
@@ -1131,7 +1131,7 @@ d_entity_release(D_EntityCtxRWStore *store, D_Entity *entity)
       // rjf: remove from hash map
       {
         U64 hash = d_hash_from_handle(t->e->handle);
-        U64 slot_idx = hash%store->ctx.hash_slots_count;
+        U64 slot_idx = hash_index64(hash, store->ctx.hash_slots_count);
         D_EntityHashSlot *slot = &store->ctx.hash_slots[slot_idx];
         D_EntityHashNode *node = 0;
         for(D_EntityHashNode *n = slot->first; n != 0; n = n->next)
@@ -1516,7 +1516,7 @@ d_thread_read_reg_block(D_Handle handle, void *reg_block)
       D_Entity *process = d_process_from_entity(thread);
       D_DumpCache *cache = &d_ctrl_state->dump_cache;
       U64 hash = d_hash_from_handle(process->handle);
-      U64 slot_idx = hash%cache->slots_count;
+      U64 slot_idx = hash_index64(hash, cache->slots_count);
       Stripe *stripe = stripe_from_slot_idx(&cache->stripes, slot_idx);
       RWMutexScope(stripe->rw_mutex, 0)
       {
@@ -1647,7 +1647,7 @@ d_cached_reg_block_from_thread(Arena *arena, D_Handle handle)
   ARCH_Info *arch_info = arch_info_from_arch(arch);
   U64 reg_block_size = arch_info->reg_block_size;
   U64 hash = d_hash_from_handle(handle);
-  U64 slot_idx = hash%cache->slots_count;
+  U64 slot_idx = hash_index64(hash, cache->slots_count);
   U64 stripe_idx = slot_idx%cache->stripes_count;
   D_ThreadRegCacheSlot *slot = &cache->slots[slot_idx];
   D_ThreadRegCacheStripe *stripe = &cache->stripes[stripe_idx];
@@ -1736,7 +1736,7 @@ d_info_from_module(Access *access, D_Handle module)
   {
     D_ModuleInfoCache *cache = &d_ctrl_state->module_info_cache;
     U64 hash = d_hash_from_handle(module);
-    U64 slot_idx = hash%cache->slots_count;
+    U64 slot_idx = hash_index64(hash, cache->slots_count);
     D_ModuleInfoCacheSlot *slot = &cache->slots[slot_idx];
     Stripe *stripe = stripe_from_slot_idx(&cache->stripes, slot_idx);
     MutexScopeR(stripe->rw_mutex) for(D_ModuleInfoCacheNode *n = slot->first; n != 0; n = n->next)
@@ -2755,7 +2755,7 @@ d_ctrl_thread__module_open(D_Handle process, D_Handle module, U64 base_vaddr, DM
   {
     D_ModuleInfoCache *cache = &d_ctrl_state->module_info_cache;
     U64 hash = d_hash_from_handle(module);
-    U64 slot_idx = hash%cache->slots_count;
+    U64 slot_idx = hash_index64(hash, cache->slots_count);
     D_ModuleInfoCacheSlot *slot = &cache->slots[slot_idx];
     Stripe *stripe = stripe_from_slot_idx(&cache->stripes, slot_idx);
     MutexScopeW(stripe->rw_mutex)
@@ -2795,7 +2795,7 @@ d_ctrl_thread__module_close(D_Handle process, D_Handle module, U64 base_vaddr)
   {
     D_ModuleInfoCache *cache = &d_ctrl_state->module_info_cache;
     U64 hash = d_hash_from_handle(module);
-    U64 slot_idx = hash%cache->slots_count;
+    U64 slot_idx = hash_index64(hash, cache->slots_count);
     Stripe *stripe = stripe_from_slot_idx(&cache->stripes, slot_idx);
     D_ModuleInfoCacheSlot *slot = &cache->slots[slot_idx];
     MutexScopeW(stripe->rw_mutex) for(;;)
@@ -2863,7 +2863,7 @@ d_ctrl_thread__close_dump_process(D_MsgID msg_id, D_Handle process)
   {
     D_DumpCache *cache = &d_ctrl_state->dump_cache;
     U64 hash = d_hash_from_handle(process);
-    U64 slot_idx = hash%cache->slots_count;
+    U64 slot_idx = hash_index64(hash, cache->slots_count);
     Stripe *stripe = stripe_from_slot_idx(&cache->stripes, slot_idx);
     
     // rjf: remove node
@@ -3486,7 +3486,7 @@ d_ctrl_thread__eval_scope_begin(Arena *arena, D_BreakpointList *user_bps, D_Enti
           {
             // rjf: find cached result
             U64 hash = d_hash_from_handle(mod->handle);
-            U64 slot_idx = hash%d_ctrl_state->module_req_cache_slots_count;
+            U64 slot_idx = hash_index64(hash, d_ctrl_state->module_req_cache_slots_count);
             D_ModuleReqCacheNode *slot = d_ctrl_state->module_req_cache_slots[slot_idx];
             D_ModuleReqCacheNode *node = 0;
             for(D_ModuleReqCacheNode *n = slot; n != 0; n = n->next)
@@ -4034,7 +4034,7 @@ d_ctrl_thread__open_crash_dump(DMN_CtrlCtx *ctrl_ctx, D_Msg *msg)
   {
     U64 hash = d_hash_from_handle(process);
     D_DumpCache *cache = &d_ctrl_state->dump_cache;
-    U64 slot_idx = hash%cache->slots_count;
+    U64 slot_idx = hash_index64(hash, cache->slots_count);
     Stripe *stripe = stripe_from_slot_idx(&cache->stripes, slot_idx);
     RWMutexScope(stripe->rw_mutex, 1)
     {
@@ -5552,7 +5552,7 @@ d_process_read(D_Handle process, Rng1U64 range, void *dst)
     {
       D_DumpCache *cache = &d_ctrl_state->dump_cache;
       U64 hash = d_hash_from_handle(process);
-      U64 slot_idx = hash%cache->slots_count;
+      U64 slot_idx = hash_index64(hash, cache->slots_count);
       Stripe *stripe = stripe_from_slot_idx(&cache->stripes, slot_idx);
       RWMutexScope(stripe->rw_mutex, 0)
       {
@@ -6123,7 +6123,7 @@ d_call_stack_artifact_create(String8 key, B32 *cancel_signal, AC_Status *status_
           if(dst_e != &d_entity_nil)
           {
             U64 hash = d_hash_from_handle(dst_e->handle);
-            U64 slot_idx = hash%dst_ctx->hash_slots_count;
+            U64 slot_idx = hash_index64(hash, dst_ctx->hash_slots_count);
             D_EntityHashSlot *slot = &dst_ctx->hash_slots[slot_idx];
             D_EntityHashNode *node = 0;
             for(D_EntityHashNode *n = slot->first; n != 0; n = n->next)

--- a/src/dbg_engine/dbg_engine_user.c
+++ b/src/dbg_engine/dbg_engine_user.c
@@ -1448,7 +1448,7 @@ d_query_cached_locals_map_from_dbgi_key_voff(DI_Key dbgi_key, U64 voff)
       break;
     }
     U64 hash = u64_hash_from_str8(str8_struct(&dbgi_key));
-    U64 slot_idx = hash % cache->table_size;
+    U64 slot_idx = hash_index64(hash, cache->table_size);
     D_RunLocalsCacheSlot *slot = &cache->table[slot_idx];
     D_RunLocalsCacheNode *node = 0;
     for(D_RunLocalsCacheNode *n = slot->first; n != 0; n = n->hash_next)
@@ -1502,7 +1502,7 @@ d_query_cached_member_map_from_dbgi_key_voff(DI_Key dbgi_key, U64 voff)
       break;
     }
     U64 hash = u64_hash_from_str8(str8_struct(&dbgi_key));
-    U64 slot_idx = hash % cache->table_size;
+    U64 slot_idx = hash_index64(hash, cache->table_size);
     D_RunLocalsCacheSlot *slot = &cache->table[slot_idx];
     D_RunLocalsCacheNode *node = 0;
     for(D_RunLocalsCacheNode *n = slot->first; n != 0; n = n->hash_next)

--- a/src/dbg_info/dbg_info.c
+++ b/src/dbg_info/dbg_info.c
@@ -117,7 +117,7 @@ di_key_from_path_timestamp(String8 path, U64 min_timestamp)
 {
   //- rjf: unpack key
   U64 hash = u64_hash_from_str8(path);
-  U64 slot_idx = hash%di_shared->path2key_slots_count;
+  U64 slot_idx = hash_index64(hash, di_shared->path2key_slots_count);
   DI_KeySlot *slot = &di_shared->path2key_slots[slot_idx];
   Stripe *stripe = stripe_from_slot_idx(&di_shared->path2key_stripes, slot_idx);
   
@@ -225,7 +225,7 @@ di_key_from_path_timestamp(String8 path, U64 min_timestamp)
       if(made_key)
       {
         U64 key_hash = u64_hash_from_str8(str8_struct(&key));
-        U64 key_slot_idx = key_hash%di_shared->key2path_slots_count;
+        U64 key_slot_idx = hash_index64(key_hash, di_shared->key2path_slots_count);
         DI_KeySlot *key_slot = &di_shared->key2path_slots[key_slot_idx];
         Stripe *key_stripe = stripe_from_slot_idx(&di_shared->key2path_stripes, key_slot_idx);
         RWMutexScope(key_stripe->rw_mutex, 1)
@@ -271,7 +271,7 @@ di_open(DI_Key key)
 {
   //- rjf: unpack key
   U64 hash = u64_hash_from_str8(str8_struct(&key));
-  U64 slot_idx = hash%di_shared->slots_count;
+  U64 slot_idx = hash_index64(hash, di_shared->slots_count);
   DI_Slot *slot = &di_shared->slots[slot_idx];
   Stripe *stripe = stripe_from_slot_idx(&di_shared->stripes, slot_idx);
   
@@ -329,7 +329,7 @@ di_close(DI_Key key, B32 force_closed)
 {
   //- rjf: unpack key
   U64 hash = u64_hash_from_str8(str8_struct(&key));
-  U64 slot_idx = hash%di_shared->slots_count;
+  U64 slot_idx = hash_index64(hash, di_shared->slots_count);
   DI_Slot *slot = &di_shared->slots[slot_idx];
   Stripe *stripe = stripe_from_slot_idx(&di_shared->stripes, slot_idx);
   
@@ -459,7 +459,7 @@ di_rdi_from_key(Access *access, DI_Key key, B32 high_priority, U64 endt_us)
   RDI_Parsed *rdi = &rdi_parsed_nil;
   {
     U64 hash = u64_hash_from_str8(str8_struct(&key));
-    U64 slot_idx = hash%di_shared->slots_count;
+    U64 slot_idx = hash_index64(hash, di_shared->slots_count);
     DI_Slot *slot = &di_shared->slots[slot_idx];
     Stripe *stripe = stripe_from_slot_idx(&di_shared->stripes, slot_idx);
     RWMutexScope(stripe->rw_mutex, 0) for(;;)
@@ -622,7 +622,7 @@ di_async_tick(void)
         B32 request_is_duplicate = 1;
         {
           U64 hash = u64_hash_from_str8(str8_struct(&key));
-          U64 slot_idx = hash%di_shared->slots_count;
+          U64 slot_idx = hash_index64(hash, di_shared->slots_count);
           DI_Slot *slot = &di_shared->slots[slot_idx];
           Stripe *stripe = stripe_from_slot_idx(&di_shared->stripes, slot_idx);
           RWMutexScope(stripe->rw_mutex, 0)
@@ -669,7 +669,7 @@ di_async_tick(void)
         //- rjf: unpack key
         DI_Key key = t->key;
         U64 key_hash = u64_hash_from_str8(str8_struct(&key));
-        U64 key_slot_idx = key_hash%di_shared->key2path_slots_count;
+        U64 key_slot_idx = hash_index64(key_hash, di_shared->key2path_slots_count);
         DI_KeySlot *key_slot = &di_shared->key2path_slots[key_slot_idx];
         Stripe *key_stripe = stripe_from_slot_idx(&di_shared->key2path_stripes, key_slot_idx);
         
@@ -847,7 +847,7 @@ di_async_tick(void)
         if(ready_to_launch_conversion)
         {
           U64 path2key_hash = u64_hash_from_str8(og_path);
-          U64 path2key_slot_idx = path2key_hash%di_shared->path2key_slots_count;
+          U64 path2key_slot_idx = hash_index64(path2key_hash, di_shared->path2key_slots_count);
           DI_KeySlot *path2key_slot = &di_shared->path2key_slots[path2key_slot_idx];
           Stripe *path2key_stripe = stripe_from_slot_idx(&di_shared->path2key_stripes, path2key_slot_idx);
           RWMutexScope(path2key_stripe->rw_mutex, 0)
@@ -1053,7 +1053,7 @@ di_async_tick(void)
       {
         ProfMsg("commit %.*s", str8_varg(rdi_path));
         U64 hash = u64_hash_from_str8(str8_struct(&key));
-        U64 slot_idx = hash%di_shared->slots_count;
+        U64 slot_idx = hash_index64(hash, di_shared->slots_count);
         DI_Slot *slot = &di_shared->slots[slot_idx];
         Stripe *stripe = stripe_from_slot_idx(&di_shared->stripes, slot_idx);
         RWMutexScope(stripe->rw_mutex, 1)

--- a/src/draw/draw.c
+++ b/src/draw/draw.c
@@ -447,7 +447,7 @@ dr_mesh(R_Handle mesh_vertices, R_Handle mesh_indices, R_GeoTopologyKind mesh_ge
       (U64)dr_top_tex2d_sample_kind(),
     };
     hash = dr_hash_from_string(str8((U8 *)buffer, sizeof(buffer)));
-    slot_idx = hash%params->mesh_batches.slots_count;
+    slot_idx = hash_index64(hash, params->mesh_batches.slots_count);
   }
   
   // rjf: map hash -> existing batch group node

--- a/src/eval/eval_core.c
+++ b/src/eval/eval_core.c
@@ -210,7 +210,7 @@ e_string2num_map_insert(Arena *arena, E_String2NumMap *map, String8 string, U64 
   if(string.size != 0)
   {
     U64 hash = e_hash_from_string(5381, string);
-    U64 slot_idx = hash%map->slots_count;
+    U64 slot_idx = hash_index64(hash, map->slots_count);
     E_String2NumMapNode *existing_node = 0;
     for(E_String2NumMapNode *node = map->slots[slot_idx].first; node != 0; node = node->hash_next)
     {
@@ -239,7 +239,7 @@ e_num_from_string(E_String2NumMap *map, String8 string)
   if(map->slots_count != 0)
   {
     U64 hash = e_hash_from_string(5381, string);
-    U64 slot_idx = hash%map->slots_count;
+    U64 slot_idx = hash_index64(hash, map->slots_count);
     E_String2NumMapNode *existing_node = 0;
     for(E_String2NumMapNode *node = map->slots[slot_idx].first; node != 0; node = node->hash_next)
     {
@@ -307,7 +307,7 @@ internal void
 e_string2expr_map_insert(Arena *arena, E_String2ExprMap *map, String8 string, E_Expr *expr)
 {
   U64 hash = e_hash_from_string(5381, string);
-  U64 slot_idx = hash%map->slots_count;
+  U64 slot_idx = hash_index64(hash, map->slots_count);
   E_String2ExprMapNode *existing_node = 0;
   for(E_String2ExprMapNode *node = map->slots[slot_idx].first;
       node != 0;
@@ -333,7 +333,7 @@ internal void
 e_string2expr_map_inc_poison(E_String2ExprMap *map, String8 string)
 {
   U64 hash = e_hash_from_string(5381, string);
-  U64 slot_idx = hash%map->slots_count;
+  U64 slot_idx = hash_index64(hash, map->slots_count);
   for(E_String2ExprMapNode *node = map->slots[slot_idx].first;
       node != 0;
       node = node->hash_next)
@@ -350,7 +350,7 @@ internal void
 e_string2expr_map_dec_poison(E_String2ExprMap *map, String8 string)
 {
   U64 hash = e_hash_from_string(5381, string);
-  U64 slot_idx = hash%map->slots_count;
+  U64 slot_idx = hash_index64(hash, map->slots_count);
   for(E_String2ExprMapNode *node = map->slots[slot_idx].first;
       node != 0;
       node = node->hash_next)
@@ -370,7 +370,7 @@ e_string2expr_map_lookup(E_String2ExprMap *map, String8 string)
   if(map->slots_count != 0)
   {
     U64 hash = e_hash_from_string(5381, string);
-    U64 slot_idx = hash%map->slots_count;
+    U64 slot_idx = hash_index64(hash, map->slots_count);
     E_String2ExprMapNode *existing_node = 0;
     for(E_String2ExprMapNode *node = map->slots[slot_idx].first; node != 0; node = node->hash_next)
     {
@@ -404,7 +404,7 @@ e_string2typekey_map_insert(Arena *arena, E_String2TypeKeyMap *map, String8 stri
 {
   E_String2TypeKeyNode *n = push_array(arena, E_String2TypeKeyNode, 1);
   U64 hash = e_hash_from_string(5381, string);
-  U64 slot_idx = hash%map->slots_count;
+  U64 slot_idx = hash_index64(hash, map->slots_count);
   SLLQueuePush(map->slots[slot_idx].first, map->slots[slot_idx].last, n);
   n->string = push_str8_copy(arena, string);
   n->key = key;
@@ -415,7 +415,7 @@ e_string2typekey_map_lookup(E_String2TypeKeyMap *map, String8 string)
 {
   E_TypeKey key = zero_struct;
   U64 hash = e_hash_from_string(5381, string);
-  U64 slot_idx = hash%map->slots_count;
+  U64 slot_idx = hash_index64(hash, map->slots_count);
   for(E_String2TypeKeyNode *n = map->slots[slot_idx].first; n != 0; n = n->next)
   {
     if(str8_match(n->string, string, 0))
@@ -508,7 +508,7 @@ e_auto_hook_map_insert_new_(Arena *arena, E_AutoHookMap *map, E_AutoHookParams *
     if(!e_type_key_match(e_type_key_zero(), type_key))
     {
       U64 hash = e_hash_from_string(5381, node->type_string);
-      U64 slot_idx = hash%map->slots_count;
+      U64 slot_idx = hash_index64(hash, map->slots_count);
       SLLQueuePush_N(map->slots[slot_idx].first, map->slots[slot_idx].last, node, hash_next);
     }
     else
@@ -874,7 +874,7 @@ e_locals_map_from_dbgi_key_voff(DI_Key dbgi_key, U64 voff)
     e_cache->locals_map_map_slots = push_array(e_cache->arena, E_LocalMapCacheSlot, e_cache->locals_map_map_slots_count);
   }
   U64 hash = u64_hash_from_seed_str8(voff, str8_struct(&dbgi_key));
-  U64 slot_idx = hash%e_cache->locals_map_map_slots_count;
+  U64 slot_idx = hash_index64(hash, e_cache->locals_map_map_slots_count);
   E_LocalMapCacheSlot *slot = &e_cache->locals_map_map_slots[slot_idx];
   E_LocalMapCacheNode *node = 0;
   for(E_LocalMapCacheNode *n = slot->first; n != 0; n = n->next)
@@ -907,7 +907,7 @@ e_member_map_from_dbgi_key_voff(DI_Key dbgi_key, U64 voff)
     e_cache->member_map_map_slots = push_array(e_cache->arena, E_LocalMapCacheSlot, e_cache->member_map_map_slots_count);
   }
   U64 hash = u64_hash_from_seed_str8(voff, str8_struct(&dbgi_key));
-  U64 slot_idx = hash%e_cache->member_map_map_slots_count;
+  U64 slot_idx = hash_index64(hash, e_cache->member_map_map_slots_count);
   E_LocalMapCacheSlot *slot = &e_cache->member_map_map_slots[slot_idx];
   E_LocalMapCacheNode *node = 0;
   for(E_LocalMapCacheNode *n = slot->first; n != 0; n = n->next)
@@ -976,7 +976,7 @@ e_key_from_string(String8 string)
     parent_key = e_cache->top_parent_node->key;
   }
   U64 hash = e_hash_from_string(parent_key.u64, string);
-  U64 slot_idx = hash%e_cache->string_slots_count;
+  U64 slot_idx = hash_index64(hash, e_cache->string_slots_count);
   E_CacheSlot *slot = &e_cache->string_slots[slot_idx];
   E_CacheNode *node = 0;
   for(E_CacheNode *n = slot->first; n != 0; n = n->string_next)
@@ -995,7 +995,7 @@ e_key_from_string(String8 string)
     e_cache->key_id_gen += 1;
     E_Key key = {e_cache->key_id_gen};
     U64 key_hash = e_hash_from_string(5381, str8_struct(&key));
-    U64 key_slot_idx = key_hash%e_cache->key_slots_count;
+    U64 key_slot_idx = hash_index64(key_hash, e_cache->key_slots_count);
     E_CacheSlot *key_slot = &e_cache->key_slots[key_slot_idx];
     node = push_array(e_cache->arena, E_CacheNode, 1);
     SLLQueuePush_N(slot->first, slot->last, node, string_next);
@@ -1036,7 +1036,7 @@ internal E_CacheBundle *
 e_cache_bundle_from_key(E_Key key)
 {
   U64 hash = e_hash_from_string(5381, str8_struct(&key));
-  U64 slot_idx = hash%e_cache->key_slots_count;
+  U64 slot_idx = hash_index64(hash, e_cache->key_slots_count);
   E_CacheSlot *slot = &e_cache->key_slots[slot_idx];
   E_CacheNode *node = 0;
   for(E_CacheNode *n = slot->first; n != 0; n = n->key_next)
@@ -1284,7 +1284,7 @@ e_push_auto_hook_matches_from_type_key(Arena *arena, E_TypeKey type_key)
     if(map != 0 && map->slots_count != 0)
     {
       U64 hash = e_hash_from_string(5381, type_string);
-      U64 slot_idx = hash%map->slots_count;
+      U64 slot_idx = hash_index64(hash, map->slots_count);
       for(E_AutoHookNode *n = map->slots[slot_idx].first; n != 0; n = n->hash_next)
       {
         if(str8_match(n->type_string, type_string, 0))
@@ -1431,7 +1431,7 @@ e_auto_hook_matches_from_type_key(E_TypeKey type_key)
   E_AutoHookMatchList matches = {0};
   {
     U64 hash = e_hash_from_string(5381, str8_struct(&type_key));
-    U64 slot_idx = hash%e_cache->type_auto_hook_cache_map->slots_count;
+    U64 slot_idx = hash_index64(hash, e_cache->type_auto_hook_cache_map->slots_count);
     E_TypeAutoHookCacheNode *node = 0;
     for(E_TypeAutoHookCacheNode *n = e_cache->type_auto_hook_cache_map->slots[slot_idx].first;
         n != 0;
@@ -1460,7 +1460,7 @@ internal U64
 e_id_from_string(String8 string)
 {
   U64 hash = e_hash_from_string(5381, string);
-  U64 hash_slot_idx = hash%e_cache->string_id_map->hash_slots_count;
+  U64 hash_slot_idx = hash_index64(hash, e_cache->string_id_map->hash_slots_count);
   E_StringIDNode *node = 0;
   for(E_StringIDNode *n = e_cache->string_id_map->hash_slots[hash_slot_idx].first; n != 0; n = n->hash_next)
   {

--- a/src/eval/eval_ir.c
+++ b/src/eval/eval_ir.c
@@ -334,7 +334,7 @@ e_expr_is_poisoned(E_Expr *expr)
 {
   B32 tag_is_poisoned = 0;
   U64 hash = e_hash_from_string(5381, str8_struct(&expr));
-  U64 slot_idx = hash%e_cache->used_expr_map->slots_count;
+  U64 slot_idx = hash_index64(hash, e_cache->used_expr_map->slots_count);
   for(E_UsedExprNode *n = e_cache->used_expr_map->slots[slot_idx].first; n != 0; n = n->next)
   {
     if(n->expr == expr)
@@ -350,7 +350,7 @@ internal void
 e_expr_poison(E_Expr *expr)
 {
   U64 hash = e_hash_from_string(5381, str8_struct(&expr));
-  U64 slot_idx = hash%e_cache->used_expr_map->slots_count;
+  U64 slot_idx = hash_index64(hash, e_cache->used_expr_map->slots_count);
   E_UsedExprNode *n = push_array(e_cache->arena, E_UsedExprNode, 1);
   n->expr = expr;
   DLLPushBack(e_cache->used_expr_map->slots[slot_idx].first, e_cache->used_expr_map->slots[slot_idx].last, n);
@@ -360,7 +360,7 @@ internal void
 e_expr_unpoison(E_Expr *expr)
 {
   U64 hash = e_hash_from_string(5381, str8_struct(&expr));
-  U64 slot_idx = hash%e_cache->used_expr_map->slots_count;
+  U64 slot_idx = hash_index64(hash, e_cache->used_expr_map->slots_count);
   for(E_UsedExprNode *n = e_cache->used_expr_map->slots[slot_idx].first; n != 0; n = n->next)
   {
     if(n->expr == expr)

--- a/src/eval/eval_types.c
+++ b/src/eval/eval_types.c
@@ -361,7 +361,7 @@ internal E_TypeKey
 e_type_key_cons_(E_ConsTypeParams *params)
 {
   U64 content_hash = e_hash_from_cons_type_params(params);
-  U64 content_slot_idx = content_hash%e_cache->cons_content_slots_count;
+  U64 content_slot_idx = hash_index64(content_hash, e_cache->cons_content_slots_count);
   E_ConsTypeSlot *content_slot = &e_cache->cons_content_slots[content_slot_idx];
   E_ConsTypeNode *node = 0;
   for(E_ConsTypeNode *n = content_slot->first; n != 0; n = n->content_next)
@@ -380,7 +380,7 @@ e_type_key_cons_(E_ConsTypeParams *params)
     key.u32[1] = (U32)e_cache->cons_id_gen;
     e_cache->cons_id_gen += 1;
     U64 key_hash = e_hash_from_string(5381, str8_struct(&key));
-    U64 key_slot_idx = key_hash%e_cache->cons_key_slots_count;
+    U64 key_slot_idx = hash_index64(key_hash, e_cache->cons_key_slots_count);
     E_ConsTypeSlot *key_slot = &e_cache->cons_key_slots[key_slot_idx];
     E_ConsTypeNode *node = push_array(e_cache->arena, E_ConsTypeNode, 1);
     SLLQueuePush_N(content_slot->first, content_slot->last, node, content_next);
@@ -647,7 +647,7 @@ e_type_byte_size_from_key(E_TypeKey key)
     case E_TypeKeyKind_Cons:
     {
       U64 key_hash = e_hash_from_string(5381, str8_struct(&key));
-      U64 key_slot_idx = key_hash%e_cache->cons_key_slots_count;
+      U64 key_slot_idx = hash_index64(key_hash, e_cache->cons_key_slots_count);
       E_ConsTypeSlot *key_slot = &e_cache->cons_key_slots[key_slot_idx];
       for(E_ConsTypeNode *node = key_slot->first;
           node != 0;
@@ -693,7 +693,7 @@ e_push_type_from_key(Arena *arena, E_TypeKey key)
       case E_TypeKeyKind_Cons:
       {
         U64 key_hash = e_hash_from_string(5381, str8_struct(&key));
-        U64 key_slot_idx = key_hash%e_cache->cons_key_slots_count;
+        U64 key_slot_idx = hash_index64(key_hash, e_cache->cons_key_slots_count);
         E_ConsTypeSlot *key_slot = &e_cache->cons_key_slots[key_slot_idx];
         for(E_ConsTypeNode *node = key_slot->first;
             node != 0;
@@ -2014,7 +2014,7 @@ e_type_from_key(E_TypeKey key)
   E_Type *type = &e_type_nil;
   {
     U64 hash = e_hash_from_string(5381, str8_struct(&key));
-    U64 slot_idx = hash%e_cache->type_cache_slots_count;
+    U64 slot_idx = hash_index64(hash, e_cache->type_cache_slots_count);
     E_TypeCacheNode *node = 0;
     for(E_TypeCacheNode *n = e_cache->type_cache_slots[slot_idx].first; n != 0; n = n->next)
     {
@@ -2042,7 +2042,7 @@ internal E_MemberCacheNode *
 e_member_cache_node_from_type_key(E_TypeKey key)
 {
   U64 hash = e_hash_from_string(5381, str8_struct(&key));
-  U64 slot_idx = hash%e_cache->member_cache_slots_count;
+  U64 slot_idx = hash_index64(hash, e_cache->member_cache_slots_count);
   E_MemberCacheSlot *slot = &e_cache->member_cache_slots[slot_idx];
   E_MemberCacheNode *node = 0;
   for(E_MemberCacheNode *n = slot->first; n != 0; n = n->next)
@@ -2066,7 +2066,7 @@ e_member_cache_node_from_type_key(E_TypeKey key)
     for EachIndex(idx, node->members.count)
     {
       U64 hash = e_hash_from_string(5381, node->members.v[idx].name);
-      U64 slot_idx = hash%node->member_hash_slots_count;
+      U64 slot_idx = hash_index64(hash, node->member_hash_slots_count);
       E_MemberHashNode *n = push_array(e_cache->arena, E_MemberHashNode, 1);
       SLLQueuePush(node->member_hash_slots[slot_idx].first, node->member_hash_slots[slot_idx].last, n);
       n->member_idx = idx;
@@ -2089,7 +2089,7 @@ e_type_data_members_from_key_filter__cached(E_TypeKey key, String8 filter)
     else
     {
       U64 hash = e_hash_from_string(5381, filter);
-      U64 slot_idx = hash%node->member_filter_slots_count;
+      U64 slot_idx = hash_index64(hash, node->member_filter_slots_count);
       E_MemberFilterSlot *slot = &node->member_filter_slots[slot_idx];
       E_MemberFilterNode *filter_node = 0;
       for(E_MemberFilterNode *n = slot->first; n != 0; n = n->next)
@@ -2144,7 +2144,7 @@ e_type_member_from_key_name__cached(E_TypeKey key, String8 name)
   if(node != 0 && node->member_hash_slots_count != 0)
   {
     U64 hash = e_hash_from_string(5381, name);
-    U64 slot_idx = hash%node->member_hash_slots_count;
+    U64 slot_idx = hash_index64(hash, node->member_hash_slots_count);
     for(E_MemberHashNode *n = node->member_hash_slots[slot_idx].first; n != 0; n = n->next)
     {
       if(str8_match(node->members.v[n->member_idx].name, name, 0))
@@ -2163,7 +2163,7 @@ internal E_EnumValCacheNode *
 e_enum_val_cache_node_from_type_key(E_TypeKey key)
 {
   U64 hash = e_hash_from_string(5381, str8_struct(&key));
-  U64 slot_idx = hash%e_cache->enum_val_cache_slots_count;
+  U64 slot_idx = hash_index64(hash, e_cache->enum_val_cache_slots_count);
   E_EnumValCacheSlot *slot = &e_cache->enum_val_cache_slots[slot_idx];
   E_EnumValCacheNode *node = 0;
   for(E_EnumValCacheNode *n = slot->first; n != 0; n = n->next)
@@ -2189,7 +2189,7 @@ e_enum_val_cache_node_from_type_key(E_TypeKey key)
       for EachIndex(idx, type->count)
       {
         U64 hash = e_hash_from_string(5381, type->enum_vals[idx].name);
-        U64 slot_idx = hash%node->val_hash_slots_count;
+        U64 slot_idx = hash_index64(hash, node->val_hash_slots_count);
         E_EnumValHashNode *n = push_array(e_cache->arena, E_EnumValHashNode, 1);
         SLLQueuePush(node->val_hash_slots[slot_idx].first, node->val_hash_slots[slot_idx].last, n);
         n->val_idx = idx;
@@ -2218,7 +2218,7 @@ e_type_enum_vals_from_key_filter__cached(E_TypeKey key, String8 filter)
     else
     {
       U64 hash = e_hash_from_string(5381, filter);
-      U64 slot_idx = hash%node->val_filter_slots_count;
+      U64 slot_idx = hash_index64(hash, node->val_filter_slots_count);
       E_EnumValFilterSlot *slot = &node->val_filter_slots[slot_idx];
       E_EnumValFilterNode *filter_node = 0;
       for(E_EnumValFilterNode *n = slot->first; n != 0; n = n->next)
@@ -2276,7 +2276,7 @@ e_type_enum_val_from_key_name__cached(E_TypeKey key, String8 name)
     String8 name_qualified_0 = push_str8f(scratch.arena, "%S%S", type->name, name);
     String8 name_qualified_1 = push_str8f(scratch.arena, "%S_%S", type->name, name);
     U64 hash = e_hash_from_string(5381, name);
-    U64 slot_idx = hash%node->val_hash_slots_count;
+    U64 slot_idx = hash_index64(hash, node->val_hash_slots_count);
     for(E_EnumValHashNode *n = node->val_hash_slots[slot_idx].first; n != 0; n = n->next)
     {
       if(str8_match(type->enum_vals[n->val_idx].name, name, 0) ||
@@ -2627,7 +2627,7 @@ e_list_gather_artifact_create(String8 key, B32 *cancel_signal, AC_Status *status
       B32 hit_cycle = 0;
       {
         U64 hash = u64_hash_from_str8(str8_struct(&off));
-        U64 slot_idx = hash%hit_slots_count;
+        U64 slot_idx = hash_index64(hash, hit_slots_count);
         for(HitOffsetNode *n = hit_slots[slot_idx]; n != 0; n = n->next)
         {
           if(n->off == off)
@@ -2661,7 +2661,7 @@ e_list_gather_artifact_create(String8 key, B32 *cancel_signal, AC_Status *status
       //- rjf: record this offset in our hit-offset table
       {
         U64 hash = u64_hash_from_str8(str8_struct(&off));
-        U64 slot_idx = hash%hit_slots_count;
+        U64 slot_idx = hash_index64(hash, hit_slots_count);
         HitOffsetNode *n = push_array(scratch.arena, HitOffsetNode, 1);
         n->off = off;
         SLLStackPush(hit_slots[slot_idx], n);

--- a/src/eval2/eval2.c
+++ b/src/eval2/eval2.c
@@ -18,7 +18,7 @@ e2_space_map_push(Arena *arena, E2_SpaceMap *map, E2_SpaceID space_id, Rng1U64 a
     map->slots = push_array(arena, E2_SpaceMapNode *, map->slots_count);
   }
   U64 hash = u64_hash_from_str8(str8_struct(&space_id));
-  U64 slot_idx = hash%map->slots_count;
+  U64 slot_idx = hash_index64(hash, map->slots_count);
   E2_SpaceMapNode *node = 0;
   for(E2_SpaceMapNode *n = map->slots[slot_idx]; n != 0; n = n->next)
   {
@@ -42,7 +42,7 @@ e2_space_map_read(E2_SpaceMap *map, E2_SpaceID space_id, Rng1U64 addr_range, voi
   U64 result = 0;
   {
     U64 hash = u64_hash_from_str8(str8_struct(&space_id));
-    U64 slot_idx = hash%map->slots_count;
+    U64 slot_idx = hash_index64(hash, map->slots_count);
     E2_SpaceMapNode *node = 0;
     for(E2_SpaceMapNode *n = map->slots[slot_idx]; n != 0; n = n->next)
     {
@@ -72,7 +72,7 @@ e2_expr_map_push(Arena *arena, E2_ExprMap *map, String8 name, E2_Expr *expr)
     map->slots = push_array(arena, E2_ExprMapNode *, map->slots_count);
   }
   U64 hash = u64_hash_from_str8(name);
-  U64 slot_idx = hash%map->slots_count;
+  U64 slot_idx = hash_index64(hash, map->slots_count);
   E2_ExprMapNode *node = 0;
   for(E2_ExprMapNode *n = map->slots[slot_idx]; n != 0; n = n->next)
   {
@@ -98,7 +98,7 @@ e2_expr_from_name(E2_ExprMap *map, String8 name)
   if(map->slots_count != 0)
   {
     U64 hash = u64_hash_from_str8(name);
-    U64 slot_idx = hash%map->slots_count;
+    U64 slot_idx = hash_index64(hash, map->slots_count);
     E2_ExprMapNode *node = 0;
     for(E2_ExprMapNode *n = map->slots[slot_idx]; n != 0; n = n->next)
     {

--- a/src/eval_visualization/eval_visualization_core.c
+++ b/src/eval_visualization/eval_visualization_core.c
@@ -225,7 +225,7 @@ internal EV_ExpandNode *
 ev_expand_node_from_key(EV_View *view, EV_Key key)
 {
   U64 hash = ev_hash_from_key(key);
-  U64 slot_idx = hash%view->expand_slots_count;
+  U64 slot_idx = hash_index64(hash, view->expand_slots_count);
   EV_ExpandSlot *slot = &view->expand_slots[slot_idx];
   EV_ExpandNode *node = 0;
   for(EV_ExpandNode *n = slot->first; n != 0; n = n->hash_next)
@@ -253,7 +253,7 @@ ev_view_rule_from_key(EV_View *view, EV_Key key)
   
   //- rjf: key -> hash * slot idx * slot
   U64 hash = ev_hash_from_key(key);
-  U64 slot_idx = hash%view->key_view_rule_slots_count;
+  U64 slot_idx = hash_index64(hash, view->key_view_rule_slots_count);
   EV_KeyViewRuleSlot *slot = &view->key_view_rule_slots[slot_idx];
   
   //- rjf: slot -> existing node
@@ -299,7 +299,7 @@ ev_key_set_expansion(EV_View *view, EV_Key parent_key, EV_Key key, B32 expanded)
     
     // rjf: link into table
     U64 hash = ev_hash_from_key(key);
-    U64 slot = hash % view->expand_slots_count;
+    U64 slot = hash_index64(hash, view->expand_slots_count);
     DLLPushBack_NP(view->expand_slots[slot].first, view->expand_slots[slot].last, node, hash_next, hash_prev);
     
     // rjf: link into parent
@@ -334,7 +334,7 @@ ev_key_set_expansion(EV_View *view, EV_Key parent_key, EV_Key key, B32 expanded)
   {
     // rjf: unlink from table
     U64 hash = ev_hash_from_key(key);
-    U64 slot = hash % view->expand_slots_count;
+    U64 slot = hash_index64(hash, view->expand_slots_count);
     DLLRemove_NP(view->expand_slots[slot].first, view->expand_slots[slot].last, node, hash_next, hash_prev);
     
     // rjf: unlink from tree
@@ -353,7 +353,7 @@ ev_key_set_view_rule(EV_View *view, EV_Key key, String8 view_rule_string)
 {
   //- rjf: key -> hash * slot idx * slot
   U64 hash = ev_hash_from_key(key);
-  U64 slot_idx = hash%view->key_view_rule_slots_count;
+  U64 slot_idx = hash_index64(hash, view->key_view_rule_slots_count);
   EV_KeyViewRuleSlot *slot = &view->key_view_rule_slots[slot_idx];
   
   //- rjf: slot -> existing node
@@ -398,7 +398,7 @@ ev_expand_rule_table_push(Arena *arena, EV_ExpandRuleTable *table, EV_ExpandRule
     table->slots = push_array(arena, EV_ExpandRuleSlot, table->slots_count);
   }
   U64 hash = ev_hash_from_seed_string(5381, info->string);
-  U64 slot_idx = hash%table->slots_count;
+  U64 slot_idx = hash_index64(hash, table->slots_count);
   EV_ExpandRuleSlot *slot = &table->slots[slot_idx];
   EV_ExpandRuleNode *n = push_array(arena, EV_ExpandRuleNode, 1);
   SLLQueuePush(slot->first, slot->last, n);
@@ -419,7 +419,7 @@ ev_expand_rule_from_string(String8 string)
   if(ev_view_rule_info_table != 0 && ev_view_rule_info_table->slots_count != 0)
   {
     U64 hash = ev_hash_from_seed_string(5381, string);
-    U64 slot_idx = hash%ev_view_rule_info_table->slots_count;
+    U64 slot_idx = hash_index64(hash, ev_view_rule_info_table->slots_count);
     EV_ExpandRuleSlot *slot = &ev_view_rule_info_table->slots[slot_idx];
     EV_ExpandRuleNode *node = 0;
     for(EV_ExpandRuleNode *n = slot->first; n != 0; n = n->next)

--- a/src/file_stream/file_stream.c
+++ b/src/file_stream/file_stream.c
@@ -168,7 +168,7 @@ fs_artifact_create(String8 key, B32 *cancel_signal, AC_Status *status_out, U64 *
   U64 path_hash = u64_hash_from_str8(path);
   if(lane_idx() == 0 && read_good)
   {
-    U64 slot_idx = path_hash%fs_shared->slots_count;
+    U64 slot_idx = hash_index64(path_hash, fs_shared->slots_count);
     FS_Slot *slot = &fs_shared->slots[slot_idx];
     Stripe *stripe = stripe_from_slot_idx(&fs_shared->stripes, slot_idx);
     RWMutexScope(stripe->rw_mutex, 1)
@@ -238,7 +238,7 @@ fs_key_from_path_range(String8 path, Rng1U64 range, U64 endt_us)
     U64 gen = 0;
     {
       U64 hash = u64_hash_from_str8(path);
-      U64 slot_idx = hash%fs_shared->slots_count;
+      U64 slot_idx = hash_index64(hash, fs_shared->slots_count);
       FS_Slot *slot = &fs_shared->slots[slot_idx];
       Stripe *stripe = stripe_from_slot_idx(&fs_shared->stripes, slot_idx);
       RWMutexScope(stripe->rw_mutex, 0)

--- a/src/font_cache/font_cache.c
+++ b/src/font_cache/font_cache.c
@@ -59,7 +59,7 @@ internal FP_Handle
 fnt_handle_from_tag(FNT_Tag tag)
 {
   ProfBeginFunction();
-  U64 slot_idx = tag.u64[1] % fnt_state->font_hash_table_size;
+  U64 slot_idx = hash_index64(tag.u64[1], fnt_state->font_hash_table_size);
   FNT_FontHashNode *existing_node = 0;
   {
     for(FNT_FontHashNode *n = fnt_state->font_hash_table[slot_idx].first; n != 0 ; n = n->hash_next)
@@ -84,7 +84,7 @@ internal FP_Metrics
 fnt_fp_metrics_from_tag(FNT_Tag tag)
 {
   ProfBeginFunction();
-  U64 slot_idx = tag.u64[1] % fnt_state->font_hash_table_size;
+  U64 slot_idx = hash_index64(tag.u64[1], fnt_state->font_hash_table_size);
   FNT_FontHashNode *existing_node = 0;
   {
     for(FNT_FontHashNode *n = fnt_state->font_hash_table[slot_idx].first; n != 0 ; n = n->hash_next)
@@ -119,7 +119,7 @@ fnt_tag_from_path(String8 path)
   }
   
   //- rjf: tag -> slot index
-  U64 slot_idx = result.u64[1] % fnt_state->font_hash_table_size;
+  U64 slot_idx = hash_index64(result.u64[1], fnt_state->font_hash_table_size);
   
   //- rjf: slot * tag -> existing node
   FNT_FontHashNode *existing_node = 0;
@@ -172,7 +172,7 @@ fnt_tag_from_static_data_string(String8 *data_ptr)
   }
   
   //- rjf: tag -> slot index
-  U64 slot_idx = result.u64[1] % fnt_state->font_hash_table_size;
+  U64 slot_idx = hash_index64(result.u64[1], fnt_state->font_hash_table_size);
   
   //- rjf: slot * tag -> existing node
   FNT_FontHashNode *existing_node = 0;
@@ -209,7 +209,7 @@ internal String8
 fnt_path_from_tag(FNT_Tag tag)
 {
   //- rjf: tag -> slot index
-  U64 slot_idx = tag.u64[1] % fnt_state->font_hash_table_size;
+  U64 slot_idx = hash_index64(tag.u64[1], fnt_state->font_hash_table_size);
   
   //- rjf: slot * tag -> existing node
   FNT_FontHashNode *existing_node = 0;
@@ -530,7 +530,7 @@ fnt_hash2style_from_tag_size_flags(FNT_Tag tag, F32 size, FNT_RasterFlags flags)
   //- rjf: style hash -> style node
   FNT_Hash2StyleRasterCacheNode *hash2style_node = 0;
   {
-    U64 slot_idx = style_hash%fnt_state->hash2style_slots_count;
+    U64 slot_idx = hash_index64(style_hash, fnt_state->hash2style_slots_count);
     FNT_Hash2StyleRasterCacheSlot *slot = &fnt_state->hash2style_slots[slot_idx];
     for(FNT_Hash2StyleRasterCacheNode *n = slot->first;
         n != 0;
@@ -575,7 +575,7 @@ fnt_run_from_string(FNT_Tag tag, F32 size, F32 base_align_px, F32 tab_size_px, F
   
   //- rjf: unpack run params
   U64 run_hash = fnt_little_hash_from_string(5381, string);
-  U64 run_slot_idx = run_hash%hash2style_node->run_slots_count;
+  U64 run_slot_idx = hash_index64(run_hash, hash2style_node->run_slots_count);
   FNT_RunCacheSlot *run_slot = &hash2style_node->run_slots[run_slot_idx];
   
   //- rjf: find existing run node for this string
@@ -666,7 +666,7 @@ fnt_run_from_string(FNT_Tag tag, F32 size, F32 base_align_px, F32 tab_size_px, F
         if(piece_substring.size > 1)
         {
           piece_hash = fnt_little_hash_from_string(5381, piece_substring);
-          U64 slot_idx = piece_hash%hash2style_node->hash2info_slots_count;
+          U64 slot_idx = hash_index64(piece_hash, hash2style_node->hash2info_slots_count);
           FNT_Hash2InfoRasterCacheSlot *slot = &hash2style_node->hash2info_slots[slot_idx];
           for(FNT_Hash2InfoRasterCacheNode *node = slot->first; node != 0; node = node->hash_next)
           {
@@ -690,7 +690,7 @@ fnt_run_from_string(FNT_Tag tag, F32 size, F32 base_align_px, F32 tab_size_px, F
           font_handle_mapped_on_miss = 1;
           
           // rjf: tag -> font slot index
-          U64 font_slot_idx = tag.u64[1] % fnt_state->font_hash_table_size;
+          U64 font_slot_idx = hash_index64(tag.u64[1], fnt_state->font_hash_table_size);
           
           // rjf: tag * slot -> existing node
           FNT_FontHashNode *existing_node = 0;
@@ -786,7 +786,7 @@ fnt_run_from_string(FNT_Tag tag, F32 size, F32 base_align_px, F32 tab_size_px, F
           }
           else
           {
-            U64 slot_idx = piece_hash%hash2style_node->hash2info_slots_count;
+            U64 slot_idx = hash_index64(piece_hash, hash2style_node->hash2info_slots_count);
             FNT_Hash2InfoRasterCacheSlot *slot = &hash2style_node->hash2info_slots[slot_idx];
             FNT_Hash2InfoRasterCacheNode *node = push_array_no_zero(fnt_state->raster_arena, FNT_Hash2InfoRasterCacheNode, 1);
             DLLPushBack_NP(slot->first, slot->last, node, hash_next, hash_prev);

--- a/src/mutable_text/mutable_text.c
+++ b/src/mutable_text/mutable_text.c
@@ -41,7 +41,7 @@ internal void
 mtx_push_op(C_Key buffer_key, MTX_Op op)
 {
   U64 hash = u64_hash_from_str8(str8_struct(&buffer_key));
-  MTX_MutThread *thread = &mtx_shared->mut_threads[hash%mtx_shared->mut_threads_count];
+  MTX_MutThread *thread = &mtx_shared->mut_threads[hash_index64(hash, mtx_shared->mut_threads_count)];
   mtx_enqueue_op(thread, buffer_key, op);
 }
 

--- a/src/raddbg/raddbg_core.c
+++ b/src/raddbg/raddbg_core.c
@@ -65,7 +65,7 @@ internal void
 rd_view_ui_rule_map_insert(Arena *arena, RD_ViewUIRuleMap *map, String8 string, RD_ViewUIFunctionType *ui)
 {
   U64 hash = d_hash_from_string(string);
-  U64 slot_idx = hash%map->slots_count;
+  U64 slot_idx = hash_index64(hash, map->slots_count);
   RD_ViewUIRuleNode *n = push_array(arena, RD_ViewUIRuleNode, 1);
   n->v.name = push_str8_copy(arena, string);
   n->v.ui = ui;
@@ -79,7 +79,7 @@ rd_view_ui_rule_from_string(String8 string)
   {
     RD_ViewUIRuleMap *map = rd_state->view_ui_rule_map;
     U64 hash = d_hash_from_string(string);
-    U64 slot_idx = hash%map->slots_count;
+    U64 slot_idx = hash_index64(hash, map->slots_count);
     for(RD_ViewUIRuleNode *n = map->slots[slot_idx].first; n != 0; n = n->next)
     {
       if(str8_match(n->v.name, string, 0))
@@ -1572,7 +1572,7 @@ rd_view_state_from_cfg(CFG_Node *cfg)
   else
   {
     U64 hash = d_hash_from_string(str8_struct(&id));
-    U64 slot_idx = hash%rd_state->view_state_slots_count;
+    U64 slot_idx = hash_index64(hash, rd_state->view_state_slots_count);
     RD_ViewStateSlot *slot = &rd_state->view_state_slots[slot_idx];
     for(RD_ViewState *v = slot->first; v != 0; v = v->hash_next)
     {
@@ -1596,7 +1596,7 @@ rd_view_state_from_cfg(CFG_Node *cfg)
     }
     MemoryCopyStruct(view_state, &rd_nil_view_state);
     U64 hash = d_hash_from_string(str8_struct(&id));
-    U64 slot_idx = hash%rd_state->view_state_slots_count;
+    U64 slot_idx = hash_index64(hash, rd_state->view_state_slots_count);
     RD_ViewStateSlot *slot = &rd_state->view_state_slots[slot_idx];
     DLLPushBack_NP(slot->first, slot->last, view_state, hash_next, hash_prev);
     view_state->cfg_id = id;
@@ -2618,7 +2618,7 @@ rd_view_ui(Rng2F32 rect)
                     string.size = Min(string.size, sizeof(ewv->dummy_text_edit_state.input_buffer));
                     RD_WatchPt pt = {row->block->key, row->key, rd_id_from_watch_cell(cell)};
                     U64 hash = ev_hash_from_key(pt.key);
-                    U64 slot_idx = hash%ewv->text_edit_state_slots_count;
+                    U64 slot_idx = hash_index64(hash, ewv->text_edit_state_slots_count);
                     RD_WatchViewTextEditState *edit_state = push_array(ewv->text_edit_arena, RD_WatchViewTextEditState, 1);
                     SLLStackPush_N(ewv->text_edit_state_slots[slot_idx], edit_state, pt_hash_next);
                     edit_state->pt           = pt;
@@ -5114,7 +5114,7 @@ rd_window_state_from_cfg(CFG_Node *cfg)
   else
   {
     U64 hash = d_hash_from_string(str8_struct(&id));
-    U64 slot_idx = hash%rd_state->window_state_slots_count;
+    U64 slot_idx = hash_index64(hash, rd_state->window_state_slots_count);
     RD_WindowStateSlot *slot = &rd_state->window_state_slots[slot_idx];
     for(RD_WindowState *w = slot->first; w != 0; w = w->hash_next)
     {
@@ -5199,7 +5199,7 @@ rd_window_state_from_cfg(CFG_Node *cfg)
     
     // rjf: hook up window links
     U64 hash = d_hash_from_string(str8_struct(&id));
-    U64 slot_idx = hash%rd_state->window_state_slots_count;
+    U64 slot_idx = hash_index64(hash, rd_state->window_state_slots_count);
     RD_WindowStateSlot *slot = &rd_state->window_state_slots[slot_idx];
     DLLPushBack_NPZ(&rd_nil_window_state, rd_state->first_window_state, rd_state->last_window_state, ws, order_next, order_prev);
     DLLPushBack_NP(slot->first, slot->last, ws, hash_next, hash_prev);
@@ -10210,7 +10210,7 @@ rd_vocab_info_from_code_name(String8 code_name)
   if(code_name.size != 0)
   {
     U64 hash = d_hash_from_string(code_name);
-    U64 slot_idx = hash%rd_state->vocab_info_map.single_slots_count;
+    U64 slot_idx = hash_index64(hash, rd_state->vocab_info_map.single_slots_count);
     for(RD_VocabInfoMapNode *n = rd_state->vocab_info_map.single_slots[slot_idx].first;
         n != 0;
         n = n->single_next)
@@ -10232,7 +10232,7 @@ rd_vocab_info_from_code_name_plural(String8 code_name_plural)
   if(code_name_plural.size != 0)
   {
     U64 hash = d_hash_from_string(code_name_plural);
-    U64 slot_idx = hash%rd_state->vocab_info_map.plural_slots_count;
+    U64 slot_idx = hash_index64(hash, rd_state->vocab_info_map.plural_slots_count);
     for(RD_VocabInfoMapNode *n = rd_state->vocab_info_map.plural_slots[slot_idx].first;
         n != 0;
         n = n->plural_next)
@@ -10357,7 +10357,7 @@ rd_gather_auto_exprs(Arena *arena)
                         {
                           String8 local_name = str8_from_rdi_string_idx(rdi, local->name_string_idx);
                           U64 hash = u64_hash_from_str8(local_name);
-                          U64 slot_idx = hash%seen_expr_slots_count;
+                          U64 slot_idx = hash_index64(hash, seen_expr_slots_count);
                           B32 already_seen = 0;
                           for(String8Node *n = seen_expr_slots[slot_idx]; n != 0; n = n->next)
                           {
@@ -10391,7 +10391,7 @@ rd_gather_auto_exprs(Arena *arena)
                   {
                     String8 gvar_name = fully_qualified_str8_from_rdi_symbol(arena, affected_rdi, affected_gvar);
                     U64 hash = u64_hash_from_str8(gvar_name);
-                    U64 slot_idx = hash%seen_expr_slots_count;
+                    U64 slot_idx = hash_index64(hash, seen_expr_slots_count);
                     B32 already_seen = 0;
                     for(String8Node *n = seen_expr_slots[slot_idx]; n != 0; n = n->next)
                     {
@@ -10805,8 +10805,8 @@ rd_init(CmdLine *cmdln)
       MemoryCopyStruct(&n->v, &rd_vocab_info_table[idx]);
       U64 single_hash = d_hash_from_string(n->v.code_name);
       U64 plural_hash = d_hash_from_string(n->v.code_name_plural);
-      U64 single_slot_idx = single_hash%rd_state->vocab_info_map.single_slots_count;
-      U64 plural_slot_idx = plural_hash%rd_state->vocab_info_map.plural_slots_count;
+      U64 single_slot_idx = hash_index64(single_hash, rd_state->vocab_info_map.single_slots_count);
+      U64 plural_slot_idx = hash_index64(plural_hash, rd_state->vocab_info_map.plural_slots_count);
       if(n->v.code_name.size != 0)
       {
         SLLQueuePush_N(rd_state->vocab_info_map.single_slots[single_slot_idx].first, rd_state->vocab_info_map.single_slots[single_slot_idx].last, n, single_next);
@@ -11239,7 +11239,7 @@ rd_frame(void)
       
       // rjf: touch in cache
       U64 hash = u64_hash_from_str8(str8_struct(&key));
-      U64 slot_idx = hash%rd_state->loaded_dbg_info_slots_count;
+      U64 slot_idx = hash_index64(hash, rd_state->loaded_dbg_info_slots_count);
       RD_LoadedDbgInfoSlot *slot = &rd_state->loaded_dbg_info_slots[slot_idx];
       RD_LoadedDbgInfoNode *node = 0;
       for(RD_LoadedDbgInfoNode *n = slot->first; n != 0; n = n->hash_next)
@@ -11280,7 +11280,7 @@ rd_frame(void)
         break;
       }
       U64 hash = u64_hash_from_str8(str8_struct(&n->key));
-      U64 slot_idx = hash%rd_state->loaded_dbg_info_slots_count;
+      U64 slot_idx = hash_index64(hash, rd_state->loaded_dbg_info_slots_count);
       RD_LoadedDbgInfoSlot *slot = &rd_state->loaded_dbg_info_slots[slot_idx];
       DLLRemove_NP(rd_state->loaded_dbg_info_lru_first, rd_state->loaded_dbg_info_lru_last, n, lru_next, lru_prev);
       DLLRemove_NP(slot->first, slot->last, n, hash_next, hash_prev);
@@ -11783,7 +11783,7 @@ rd_frame(void)
         try_u64_from_str8_c_rules(timestamp_node->first->string, &timestamp);
         DI_Key key = di_key_from_path_timestamp(path, timestamp);
         U64 hash = u64_hash_from_str8(str8_struct(&key));
-        U64 slot_idx = hash%dbg_info_slots_count;
+        U64 slot_idx = hash_index64(hash, dbg_info_slots_count);
         DbgInfoNode *node = 0;
         for(DbgInfoNode *n = dbg_info_slots[slot_idx]; n != 0; n = n->hash_next)
         {
@@ -11863,7 +11863,7 @@ rd_frame(void)
         U32 dbg_info_num = 0;
         {
           U64 hash = u64_hash_from_str8(str8_struct(&dbgi_key));
-          U64 slot_idx = hash%dbg_info_slots_count;
+          U64 slot_idx = hash_index64(hash, dbg_info_slots_count);
           for(DbgInfoNode *n = dbg_info_slots[slot_idx]; n != 0; n = n->hash_next)
           {
             if(di_key_match(n->key, dbgi_key))
@@ -17823,7 +17823,7 @@ rd_frame(void)
             {
               String8 name = str8_skip_last_slash(file_path);
               U64 hash = d_hash_from_string__case_insensitive(name);
-              U64 slot_idx = hash%rd_state->ambiguous_path_slots_count;
+              U64 slot_idx = hash_index64(hash, rd_state->ambiguous_path_slots_count);
               RD_AmbiguousPathNode *node = 0;
               for(RD_AmbiguousPathNode *n = rd_state->ambiguous_path_slots[slot_idx];
                   n != 0;

--- a/src/raddbg/raddbg_views.c
+++ b/src/raddbg/raddbg_views.c
@@ -2001,7 +2001,7 @@ rd_watch_view_text_edit_state_from_pt(RD_WatchViewState *wv, RD_WatchPt pt)
   if(wv->text_edit_state_slots_count != 0 && wv->text_editing != 0)
   {
     U64 hash = ev_hash_from_key(pt.key);
-    U64 slot_idx = hash%wv->text_edit_state_slots_count;
+    U64 slot_idx = hash_index64(hash, wv->text_edit_state_slots_count);
     for(RD_WatchViewTextEditState *s = wv->text_edit_state_slots[slot_idx]; s != 0; s = s->pt_hash_next)
     {
       if(rd_watch_pt_match(pt, s->pt))

--- a/src/raddbg/raddbg_widgets.c
+++ b/src/raddbg/raddbg_widgets.c
@@ -197,7 +197,7 @@ rd_title_fstrs_from_cfg(Arena *arena, CFG_Node *cfg, B32 include_extras)
       if(rd_state->ambiguous_path_slots_count != 0)
       {
         U64 hash = d_hash_from_string__case_insensitive(file_name);
-        U64 slot_idx = hash%rd_state->ambiguous_path_slots_count;
+        U64 slot_idx = hash_index64(hash, rd_state->ambiguous_path_slots_count);
         RD_AmbiguousPathNode *node = 0;
         {
           for(RD_AmbiguousPathNode *n = rd_state->ambiguous_path_slots[slot_idx];

--- a/src/text/text.c
+++ b/src/text/text.c
@@ -140,7 +140,7 @@ txt_token_array_from_lang_kind_string(Arena *arena, TXT_LangKind lang_kind, Stri
   {
     String8 keyword = txt_keywords_from_lang_kind_table[lang_kind].v[idx];
     U64 hash = u64_hash_from_str8(keyword);
-    U64 slot_idx = hash%keyword_slots_count;
+    U64 slot_idx = hash_index64(hash, keyword_slots_count);
     String8Node *n = push_array(scratch.arena, String8Node, 1);
     SLLStackPush(keyword_slots[slot_idx], n);
     n->string = keyword;
@@ -160,8 +160,8 @@ txt_token_array_from_lang_kind_string(Arena *arena, TXT_LangKind lang_kind, Stri
       TXT_TokenizerRule *r = &rules.v[idx];
       U64 open_hash = u64_hash_from_str8(r->open_string);
       U64 close_hash = u64_hash_from_str8(r->close_string);
-      U64 open_slot_idx = open_hash%tokenizer_rule_slots_count;
-      U64 close_slot_idx = close_hash%tokenizer_rule_slots_count;
+      U64 open_slot_idx = hash_index64(open_hash, tokenizer_rule_slots_count);
+      U64 close_slot_idx = hash_index64(close_hash, tokenizer_rule_slots_count);
       TXT_TokenizerRulePtrNode *open_n = push_array(scratch.arena, TXT_TokenizerRulePtrNode, 1);
       TXT_TokenizerRulePtrNode *close_n = push_array(scratch.arena, TXT_TokenizerRulePtrNode, 1);
       open_n->v = r;
@@ -225,8 +225,8 @@ txt_token_array_from_lang_kind_string(Arena *arena, TXT_LangKind lang_kind, Stri
           TXT_TokenizerRule *active_rule = top_task ? top_task->rule : nil_rule;
           U64 hash_1byte = u64_hash_from_str8(string_1byte);
           U64 hash_2byte = u64_hash_from_str8(string_2byte);
-          U64 slot_1byte = hash_1byte%tokenizer_rule_slots_count;
-          U64 slot_2byte = hash_2byte%tokenizer_rule_slots_count;
+          U64 slot_1byte = hash_index64(hash_1byte, tokenizer_rule_slots_count);
+          U64 slot_2byte = hash_index64(hash_2byte, tokenizer_rule_slots_count);
           if(new_rule == nil_rule)
           {
             for EachNode(n, TXT_TokenizerRulePtrNode, tokenizer_rule_opener_slots[slot_2byte])
@@ -389,7 +389,7 @@ txt_token_array_from_lang_kind_string(Arena *arena, TXT_LangKind lang_kind, Stri
         {
           String8 token_string = str8_substr(string, token.range);
           U64 hash = u64_hash_from_str8(token_string);
-          U64 slot_idx = hash%keyword_slots_count;
+          U64 slot_idx = hash_index64(hash, keyword_slots_count);
           for EachNode(n, String8Node, keyword_slots[slot_idx])
           {
             if(str8_match(token_string, n->string, 0))

--- a/src/ui/ui_core.c
+++ b/src/ui/ui_core.c
@@ -778,7 +778,7 @@ ui_box_from_key(UI_Key key)
   UI_Box *result = &ui_nil_box;
   if(!ui_key_match(key, ui_key_zero()))
   {
-    U64 slot = key.u64[0] % ui_state->box_table_size;
+    U64 slot = hash_index64(key.u64[0], ui_state->box_table_size);
     for(UI_Box *b = ui_state->box_table[slot].hash_first; !ui_box_is_nil(b); b = b->hash_next)
     {
       if(ui_key_match(b->key, key))
@@ -826,7 +826,7 @@ ui_begin_build(WM_Window window, UI_EventList *events, UI_IconInfo *icon_info, U
       next = n->lru_next;
       if(n->last_touched_build_index+2 < ui_state->build_index)
       {
-        U64 slot_idx = n->key.u64[0]%ui_state->anim_slots_count;
+        U64 slot_idx = hash_index64(n->key.u64[0], ui_state->anim_slots_count);
         UI_AnimSlot *slot = &ui_state->anim_slots[slot_idx];
         DLLRemove_NPZ(&ui_nil_anim_node, slot->first, slot->last, n, slot_next, slot_prev);;
         DLLRemove_NPZ(&ui_nil_anim_node, ui_state->lru_anim_node, ui_state->mru_anim_node, n, lru_next, lru_prev);
@@ -847,7 +847,7 @@ ui_begin_build(WM_Window window, UI_EventList *events, UI_IconInfo *icon_info, U
       next = n->lru_next;
       if(n->last_build_index_accessed+2 < ui_state->build_index)
       {
-        U64 slot_idx = n->key.u64[0]%ui_state->theme_pattern_cache_slots_count;
+        U64 slot_idx = hash_index64(n->key.u64[0], ui_state->theme_pattern_cache_slots_count);
         UI_ThemePatternCacheSlot *slot = &ui_state->theme_pattern_cache_slots[slot_idx];
         DLLRemove_NP(slot->first, slot->last, n, slot_next, slot_prev);
         DLLRemove_NP(ui_state->lru_theme_pattern_cache_node, ui_state->mru_theme_pattern_cache_node, n, lru_next, lru_prev);
@@ -2273,7 +2273,7 @@ ui_color_from_tags_key_extras(UI_Key key, String8Array extras)
     }
     
     //- rjf: map to existing node
-    U64 slot_idx = final_key.u64[0]%ui_state->theme_pattern_cache_slots_count;
+    U64 slot_idx = hash_index64(final_key.u64[0], ui_state->theme_pattern_cache_slots_count);
     UI_ThemePatternCacheSlot *slot = &ui_state->theme_pattern_cache_slots[slot_idx];
     UI_ThemePatternCacheNode *node = 0;
     for(UI_ThemePatternCacheNode *n = slot->first;
@@ -2292,7 +2292,7 @@ ui_color_from_tags_key_extras(UI_Key key, String8Array extras)
       // rjf: map tags_key (without name) -> full list of tags
       String8Array tags = {0};
       {
-        U64 tags_cache_slot_idx = key.u64[0]%ui_state->tags_cache_slots_count;
+        U64 tags_cache_slot_idx = hash_index64(key.u64[0], ui_state->tags_cache_slots_count);
         UI_TagsCacheSlot *tags_cache_slot = &ui_state->tags_cache_slots[tags_cache_slot_idx];
         for(UI_TagsCacheNode *n = tags_cache_slot->first; n != 0; n = n->next)
         {
@@ -2459,7 +2459,7 @@ ui_build_box_from_key(UI_BoxFlags flags, UI_Key key)
   //- rjf: hook into persistent state table
   if(box_first_frame && !box_is_transient)
   {
-    U64 slot = key.u64[0] % ui_state->box_table_size;
+    U64 slot = hash_index64(key.u64[0], ui_state->box_table_size);
     DLLInsert_NPZ(&ui_nil_box, ui_state->box_table[slot].hash_first, ui_state->box_table[slot].hash_last, ui_state->box_table[slot].hash_last, box, hash_next, hash_prev);
   }
   
@@ -3226,7 +3226,7 @@ ui_anim_(UI_Key key, UI_AnimParams *params)
   UI_AnimNode *node = &ui_nil_anim_node;
   if(ui_state != 0)
   {
-    U64 slot_idx = key.u64[0]%ui_state->anim_slots_count;
+    U64 slot_idx = hash_index64(key.u64[0], ui_state->anim_slots_count);
     UI_AnimSlot *slot = &ui_state->anim_slots[slot_idx];
     for(UI_AnimNode *n = slot->first; n != &ui_nil_anim_node && n != 0; n = n->slot_next)
     {
@@ -3363,7 +3363,7 @@ ui__push_tags_key_from_appended_string(String8 string)
   // rjf: store in tags cache
   if(!is_new_root)
   {
-    U64 slot_idx = key.u64[0] % ui_state->tags_cache_slots_count;
+    U64 slot_idx = hash_index64(key.u64[0], ui_state->tags_cache_slots_count);
     UI_TagsCacheSlot *slot = &ui_state->tags_cache_slots[slot_idx];
     UI_TagsCacheNode *node = 0;
     for(UI_TagsCacheNode *n = slot->first; n != 0; n = n->next)

--- a/src/win32/demon/win32_demon.c
+++ b/src/win32/demon/win32_demon.c
@@ -67,7 +67,7 @@ w32_dmn_entity_alloc(W32_DMN_Entity *parent, W32_DMN_EntityKind kind, U64 id)
   if(id != 0)
   {
     U64 hash = u64_hash_from_str8(str8_struct(&id));
-    U64 slot_idx = hash%w32_dmn_shared->entities_id_hash_slots_count;
+    U64 slot_idx = hash_index64(hash, w32_dmn_shared->entities_id_hash_slots_count);
     W32_DMN_EntityIDHashSlot *slot = &w32_dmn_shared->entities_id_hash_slots[slot_idx];
     W32_DMN_EntityIDHashNode *node = 0;
     for(W32_DMN_EntityIDHashNode *n = slot->first; n != 0; n = n->next)
@@ -142,7 +142,7 @@ w32_dmn_entity_release(W32_DMN_Entity *entity)
       if(t->e->id != 0)
       {
         U64 hash = u64_hash_from_str8(str8_struct(&t->e->id));
-        U64 slot_idx = hash%w32_dmn_shared->entities_id_hash_slots_count;
+        U64 slot_idx = hash_index64(hash, w32_dmn_shared->entities_id_hash_slots_count);
         W32_DMN_EntityIDHashSlot *slot = &w32_dmn_shared->entities_id_hash_slots[slot_idx];
         W32_DMN_EntityIDHashNode *node = 0;
         for(W32_DMN_EntityIDHashNode *n = slot->first; n != 0; n = n->next)
@@ -167,7 +167,7 @@ w32_dmn_entity_from_kind_id(W32_DMN_EntityKind kind, U64 id)
 {
   W32_DMN_Entity *result = &w32_dmn_entity_nil;
   U64 hash = u64_hash_from_str8(str8_struct(&id));
-  U64 slot_idx = hash%w32_dmn_shared->entities_id_hash_slots_count;
+  U64 slot_idx = hash_index64(hash, w32_dmn_shared->entities_id_hash_slots_count);
   W32_DMN_EntityIDHashSlot *slot = &w32_dmn_shared->entities_id_hash_slots[slot_idx];
   W32_DMN_EntityIDHashNode *node = 0;
   for(W32_DMN_EntityIDHashNode *n = slot->first; n != 0; n = n->next)

--- a/src/win32/symbol_server/win32_symbol_server.c
+++ b/src/win32/symbol_server/win32_symbol_server.c
@@ -338,7 +338,7 @@ smsv_async_tick(void)
       
       // rjf: evict task from cache
       U64 hash = u64_hash_from_str8(task->local_path);
-      U64 slot_idx = hash%w32_smsv_state->task_slots_count;
+      U64 slot_idx = hash_index64(hash, w32_smsv_state->task_slots_count);
       W32_SMSV_TaskSlot *slot = &w32_smsv_state->task_slots[slot_idx];
       Stripe *stripe = stripe_from_slot_idx(&w32_smsv_state->task_stripes, slot_idx);
       RWMutexScope(stripe->rw_mutex, 1)
@@ -395,7 +395,7 @@ smsv_fill_local_path(String8 path)
   if(!already_cached_locally)
   {
     U64 hash = u64_hash_from_str8(path);
-    U64 slot_idx = hash%w32_smsv_state->task_slots_count;
+    U64 slot_idx = hash_index64(hash, w32_smsv_state->task_slots_count);
     W32_SMSV_TaskSlot *slot = &w32_smsv_state->task_slots[slot_idx];
     Stripe *stripe = stripe_from_slot_idx(&w32_smsv_state->task_stripes, slot_idx);
     for(B32 write_mode = 0; write_mode <= 1; write_mode += 1)
@@ -450,7 +450,7 @@ smsv_status_from_local_path(String8 path)
     Temp scratch = scratch_begin(0, 0);
     String8 path_normalized = path_normalized_from_string(scratch.arena, path);
     U64 hash = u64_hash_from_str8(path_normalized);
-    U64 slot_idx = hash%w32_smsv_state->task_slots_count;
+    U64 slot_idx = hash_index64(hash, w32_smsv_state->task_slots_count);
     W32_SMSV_TaskSlot *slot = &w32_smsv_state->task_slots[slot_idx];
     Stripe *stripe = stripe_from_slot_idx(&w32_smsv_state->task_stripes, slot_idx);
     RWMutexScope(stripe->rw_mutex, 0)


### PR DESCRIPTION
Change how hashtable index is calculated from 64-bit hash - instead of slow division operation use a **much faster** single multiply operation.

This changes `hash % count` to `((U128)hash * count) >> 64` calculation - but shift will be no-op, as high 64-bit value of 128-bit multiplication result will be in its own register.

It will calculate different value than `hash % count` but it will still be distributed reasonably uniformly in `[0, count)` interval.

This works because you can pretend hash value is 0.64 fixed-point value representing `[0, 1)` float. Thus multiplying it with integer N will give you value in `[0, N)` interval.

I did not change files in `codeview_parse`, `dwarf_parse`, `rdi_parse`, `rdi_make`, `rdi_from_dwarf`, `rdi_from_pdb` and `linker` folders, because I'm not sure in which places hash table contents depends on actual % operation result in rdi/dwarf/pdb file formats. Probably bunch of places there also can be changed to use this faster way.