### PR TITLE
radlink: accept GNU ar (.a) archives as lib input

### DIFF
--- a/src/linker/lnk_config.c
+++ b/src/linker/lnk_config.c
@@ -119,6 +119,7 @@ global read_only struct
   { "obj",  LNK_Input_Obj },
   { "lib",  LNK_Input_Lib },
   { "rlib", LNK_Input_Lib }, // rust libs
+  { "a",    LNK_Input_Lib }, // GNU ar archives (clang/meson, e.g. libdav1d.a)
   { "res",  LNK_Input_Res },
   { "rrt",  LNK_Input_RRT },
 };


### PR DESCRIPTION
`g_input_type_map` mapped `o`/`obj`/`lib`/`rlib`/`res`/`rrt` but not `a`, so clang/meson-built GNU ar archives (e.g. UE ThirdParty `libdav1d.a`) hit `Error(002): unknown file format`.

`rlib` (Rust libs) is already mapped to `LNK_Input_Lib` and rlibs are GNU ar archives that parse fine, so `.a` routes through the same path — one-line map entry.

```c
  { "lib",  LNK_Input_Lib },
  { "rlib", LNK_Input_Lib }, // rust libs
  { "a",    LNK_Input_Lib }, // GNU ar archives (clang/meson, e.g. libdav1d.a)
  { "res",  LNK_Input_Res },
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)