### PR TITLE
Use '/usr/bin/env bash' instead of '/bin/bash' for Linux scripts.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 cd "$(dirname "$0")"
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 cd "$(dirname "$0")"
 


### PR DESCRIPTION
_(Accidentally nuked old PR while rebasing for latest changes)_

If `/usr/bin/env bash` is used in the shebangs of the Linux scripts, the `bash` that runs the script will be found in $PATH. This results in the scripts working on any systems that have `bash` available to the user, regardless of where it is located.

In many systems `/bin/bash` does not exist, as it is installed elsewhere. Using `/usr/bin/env bash` is a common way to avoid any portability issues between different Linux distributions.