### PR TITLE
radlink: fix MSF/PDB header page count and final-page extent

### DIFF
--- a/src/linker/pdb_ext/msf_builder.c
+++ b/src/linker/pdb_ext/msf_builder.c
@@ -635,9 +635,10 @@ msf_find_max_pn_(MSF_PageDataList page_data_list, MSF_UInt page_size, MSF_PageNu
       // FPM is empty
       if (msb_idx >= hi) { break; }
 
-      // hit FPM page -- keep going
+      // Skip reserved FPM pages, but not slot 0: after the file header's
+      // interval, that slot can contain stream data.
       U64 k = msb_idx % fpm_interval_wrong;
-      if (k < 3) {
+      if (k == MSF_FPM0 || k == MSF_FPM1) {
         hi = msb_idx;
         continue;
       }
@@ -648,7 +649,7 @@ msf_find_max_pn_(MSF_PageDataList page_data_list, MSF_UInt page_size, MSF_PageNu
 
     // stop if there is a page
     if (bit_idx != max_U64) {
-      max_pn = Max(bit_idx, 2) + fpm_pn_idx * fpm_interval_correct;
+      max_pn = Max(bit_idx + fpm_pn_idx * fpm_interval_correct, MSF_FPM1);
       break;
     }
   }
@@ -1607,7 +1608,9 @@ msf_build_header(MSF_Context *msf, MSF_UInt stream_table_size)
   MemoryCopy(&header.magic[0], &msf_msf70_magic[0], sizeof(msf_msf70_magic));
   header.page_size         = msf->page_size;
   header.active_fpm        = msf->active_fpm;
-  header.page_count        = msf->page_count;
+  // The allocator also counts reserved FPM pages beyond the serialized extent.
+  // The stream table and root are finalized; use the same extent as the writer.
+  header.page_count        = (MSF_UInt)(msf_get_save_size(msf) / msf->page_size);
   header.stream_table_size = stream_table_size;
   header.unknown           = 0;
   header.root_pn           = msf->root_page_list.first->pn;

--- a/src/linker/tests/linker_tests.c
+++ b/src/linker/tests/linker_tests.c
@@ -7059,6 +7059,83 @@ TEST(get_msf_stream_pages)
   msf_release(msf);
 }
 
+TEST(msf_header_matches_saved_extent)
+{
+  MSF_UInt page_sizes[] = {512, 4096};
+  MSF_UInt fpms[] = {MSF_FPM0, MSF_FPM1};
+  for EachIndex(size_idx, ArrayCount(page_sizes)) {
+    MSF_UInt page_size = page_sizes[size_idx];
+    MSF_PageNumber last_pages[] = {68, page_size - 1, page_size, page_size + 3,
+                                  page_size * 8 - 1, page_size * 8, page_size * 8 + 3};
+    // Cover an entire FPM's bitmap with small pages, and the default page size's
+    // first interval without making this a large-memory test.
+    U64 case_count = page_size == 512 ? ArrayCount(last_pages) : 4;
+    for EachIndex(fpm_idx, ArrayCount(fpms)) {
+      for EachIndex(case_idx, case_count) {
+        Temp temp = temp_begin(arena);
+        MSF_Context *msf = msf_alloc(page_size, fpms[fpm_idx]);
+
+        // Leave low pages for the stream table and root so that the final data
+        // page, not metadata, determines EOF. This also exercises a sparse file.
+        MSF_PageList gap = msf_alloc_pages(msf, 64);
+        T_Ok(gap.first->pn == 4 && gap.last->pn == 67);
+        MSF_PageNumber last_pn = last_pages[case_idx];
+        MSF_UInt data_page_count = 0;
+        for (MSF_PageNumber pn = 68; pn <= last_pn; ++pn) {
+          MSF_UInt slot = pn % page_size;
+          data_page_count += slot != MSF_FPM0 && slot != MSF_FPM1;
+        }
+        String8 payload = str8(push_array_no_zero(arena, U8, (U64)data_page_count * page_size),
+                              (U64)data_page_count * page_size);
+        MemorySet(payload.str, 0xA5, payload.size);
+        MSF_StreamNumber sn = msf_stream_alloc(msf);
+        T_Ok(msf_stream_write(msf, sn, payload.str, (MSF_UInt)payload.size));
+        T_Ok(msf_find_stream(msf, sn)->page_list.last->pn == last_pn);
+        msf_free_pages(msf, &gap);
+        T_Ok(msf_build(msf) == MSF_Error_OK);
+        T_Ok(msf->root_page_list.last->pn < last_pn);
+        T_Ok(msf->st_page_list.last->pn < last_pn);
+
+        U64 save_size = msf_get_save_size(msf);
+        T_Ok(save_size == ((U64)last_pn + 1) * page_size);
+        String8 saved = str8(push_array_no_zero(arena, U8, save_size), save_size);
+        T_Ok(msf_save(msf, saved.str, saved.size));
+        MSF_Header70 *header = (MSF_Header70 *)saved.str;
+        T_Ok((U64)header->page_count * header->page_size == saved.size);
+        String8List pages = msf_get_page_data_nodes(arena, msf);
+        T_Ok(str8_match(saved, str8_list_join(arena, &pages, 0), 0));
+
+        // Size agreement alone must not conceal a truncated final stream page.
+        MSF_Parsed *parsed = msf_parsed_from_data(arena, saved);
+        T_Ok(parsed != 0);
+        if (parsed != 0 && sn < parsed->stream_count) {
+          T_Ok(str8_match(parsed->streams[sn], payload, 0));
+        } else {
+          T_Ok(0);
+        }
+        msf_release(msf);
+        temp_end(temp);
+      }
+    }
+  }
+}
+
+TEST(pdb_header_matches_file_size)
+{
+  T_Ok(t_write_entry_obj());
+  t_invoke_linkerf("/subsystem:console /entry:entry /debug:full /out:pages.exe /pdb:pages.pdb /pdbstripped:pages.stripped.pdb entry.obj");
+  T_Ok(g_last_exit_code == 0);
+  char *pdb_paths[] = {"pages.pdb", "pages.stripped.pdb"};
+  for EachIndex(i, ArrayCount(pdb_paths)) {
+    String8 pdb = t_read_file(arena, str8_cstring(pdb_paths[i]));
+    T_Ok(pdb.size >= sizeof(MSF_Header70));
+    if (pdb.size >= sizeof(MSF_Header70)) {
+      MSF_Header70 *header = (MSF_Header70 *)pdb.str;
+      T_Ok((U64)header->page_count * header->page_size == pdb.size);
+    }
+  }
+}
+
 internal String8
 data_from_pdb(Arena *arena, PDB_Context *pdb)
 {


### PR DESCRIPTION
## Summary

Fix the MSF superblock's `page_count` so that `page_count * page_size` matches the serialized PDB length. This is a standalone correctness fix against `dev`; it does not depend on the optimization/compressed-OBJ PRs (#842, #892, #932) or the library lookup fix (#934).

A small Clang-built object linked with `/debug:full` exposed a PDB with 17 actual 4096-byte pages but a header declaring 31. Consumers which validate the superblock against file length reject that file with an unexpected-stream-length error.

## Cause and fix

`msf->page_count` tracks allocator accounting, including preallocated free-page-map (FPM) pages beyond EOF. It is not the serialized file extent. `msf_build_header()` now obtains its page count from `msf_get_save_size()` after the stream table and root have been finalized. Allocation accounting is unchanged.

Boundary regressions also exposed two issues in that extent calculation:

- Only interval slots 1 and 2 are reserved FPM pages. Slot 0 can contain stream data after the first interval, so skipping it can drop a live final page.
- The minimum extent belongs to the absolute page number, not a bitmap-relative index. Applying it before the bitmap base can add two pages at a later bitmap's boundary.

Both are corrected so that agreement between the header and file size cannot merely conceal truncated stream data. See the [MSF format documentation](https://llvm.org/docs/PDB/MsfFile.html) for the superblock and FPM layout.

## Regression coverage

Tests are added to the existing `src/linker/tests/linker_tests.c`:

- 22 in-memory cases cover both active FPMs, 512/4096-byte pages, sparse allocations, and before/at/after interval boundaries, including an entire bitmap's coverage.
- Check the expected final page, header/file-size agreement, contiguous and page-list serialization, and byte-exact stream round trips.
- Link a native COFF fixture and validate both full and stripped PDB file lengths. No external compiler is needed for these tests.

## Validation

- Confirmed the new in-memory regression fails on unmodified `dev` at the header/file-size assertion.
- Standalone PR: release and debug, **8 passed, 0 failed/crashed/skipped** (the two new regressions plus existing MSF, PDB-info, GSI, PSI and simple-link tests).
- Same implementation in the combined development build: **163 passed, 0 failed/crashed, 12 MSVC-dependent tests excluded**, in each of release and debug.
- Clang probe: fixed PDB has 17 declared and 17 actual pages (69,632 bytes). LLVM pdbutil 20.1.8 reads full and stripped outputs at page sizes 512, 1024, 2048, 4096, 8192 and 16384.
- Local integration link: DLL remained byte-identical; its 13,430,784-byte PDB differed only in the page-count field (3293 -> 3279).

Local builds used LLVM/Clang/LLD 20.1.8, not MSVC compiler/linker tools. Full application builds, UBA and symbol-upload infrastructure were not rerun for this fix. Existing affected PDBs need to be regenerated by relinking; this change does not patch them in place.
