### PR TITLE
coff: decode Base64 section-name offsets for large coverage objects

### DIFF
--- a/src/coff/coff.c
+++ b/src/coff/coff.c
@@ -55,10 +55,30 @@ internal String8
 coff_name_from_section_header(String8 string_table, COFF_SectionHeader *header)
 {
   String8 name = str8_cstring_capped(header->name, header->name + sizeof(header->name));
-  if (name.str[0] == '/') {
-    String8 name_off_str = str8_skip(name, 1);
-    U64     name_off     = u64_from_str8(name_off_str, 10);
-    name = str8_cstring_capped(string_table.str + name_off, string_table.str+string_table.size);
+  if (name.size > 0 && name.str[0] == '/') {
+    U64 name_off = 0;
+    B32 valid = 1;
+    if (name.size > 1 && name.str[1] == '/') {
+      // LLVM/GNU encode offsets that do not fit in seven decimal digits as
+      // "//" followed by up to six standard Base64 digits, most significant first.
+      valid = name.size > 2;
+      for (U64 i = 2; i < name.size && valid; i += 1) {
+        U8 c = name.str[i];
+        U64 digit = 0;
+        if      ('A' <= c && c <= 'Z') { digit = c - 'A'; }
+        else if ('a' <= c && c <= 'z') { digit = c - 'a' + 26; }
+        else if ('0' <= c && c <= '9') { digit = c - '0' + 52; }
+        else if (c == '+')            { digit = 62; }
+        else if (c == '/')            { digit = 63; }
+        else                         { valid = 0; }
+        name_off = (name_off << 6) | digit;
+      }
+    } else {
+      name_off = u64_from_str8(str8_skip(name, 1), 10);
+    }
+    name = valid && name_off < string_table.size
+         ? str8_cstring_capped(string_table.str + name_off, string_table.str + string_table.size)
+         : str8_zero();
   }
   return name;
 }

--- a/src/linker/tests/linker_tests.c
+++ b/src/linker/tests/linker_tests.c
@@ -433,6 +433,46 @@ t_write_entry_obj(void)
 
 ////////////////////////////////
 
+TEST(coff_section_name_offsets)
+{
+  String8 expected = str8_lit(".lcovfun$M");
+  U64 offsets[] = {4, 62, 63, 64, 9999999, 10000000, 13169462};
+  String8 encoded[] = {
+    str8_lit("//AAAAAE"), str8_lit("//AAAAA+"), str8_lit("//AAAAA/"),
+    str8_lit("//AAAABA"), str8_lit("//AAmJZ/"), str8_lit("//AAmJaA"),
+    str8_lit("//AAyPM2"),
+  };
+  String8 table = str8(push_array(arena, U8, 13169462 + 32), 13169462 + 32);
+  for EachIndex(i, ArrayCount(offsets)) {
+    MemoryCopy(table.str + offsets[i], expected.str, expected.size + 1);
+    COFF_SectionHeader header = {0};
+    MemoryCopy(header.name, encoded[i].str, encoded[i].size);
+    T_Ok(str8_match(coff_name_from_section_header(table, &header), expected, 0));
+    if (offsets[i] <= 9999999) {
+      String8 decimal = str8f(arena, "/%llu", offsets[i]);
+      MemoryZeroStruct(&header);
+      MemoryCopy(header.name, decimal.str, decimal.size);
+      T_Ok(str8_match(coff_name_from_section_header(table, &header), expected, 0));
+    }
+  }
+  String8 invalid[] = {
+    str8_lit("//AAAAA!"), str8_lit("//"), str8_lit("////////"),
+    str8_lit("//AAAAAE"), // offset exactly at the end of the short table below
+    str8_lit("/9999999"),
+  };
+  String8 short_table = str8_prefix(table, 4);
+  for EachIndex(i, ArrayCount(invalid)) {
+    COFF_SectionHeader header = {0};
+    MemoryCopy(header.name, invalid[i].str, invalid[i].size);
+    T_Ok(coff_name_from_section_header(short_table, &header).size == 0);
+  }
+  COFF_SectionHeader inline_header = {0};
+  MemoryCopy(inline_header.name, ".text$mn", 8);
+  T_Ok(str8_match(coff_name_from_section_header(str8_zero(), &inline_header), str8_lit(".text$mn"), 0));
+  MemoryZeroStruct(&inline_header);
+  T_Ok(coff_name_from_section_header(str8_zero(), &inline_header).size == 0);
+}
+
 TEST(coff_writer_bigobj)
 {
   // Exercise the standard-COFF boundary and an associative parent above 16 bits.


### PR DESCRIPTION
## Summary
- Decode the LLVM/GNU extended COFF section-name format: `//` followed by a most-significant-first Base64 string-table offset.
- Keep normal inline names and decimal `/offset` references unchanged, and bounds-check indirect offsets before reading the string table.
- Add regression coverage for all Base64 digit classes, the seven-digit decimal boundary, offsets above 10 MB, malformed/out-of-range references, and inline names.

## Problem
Large coverage-instrumented COFF objects can have string tables whose section-name offsets exceed 9,999,999. LLVM then emits names such as `//AAyPM2` (offset 13,169,462) for `.lcovfun$M`. Interpreting this as a decimal reference produces bogus output-section names. The coverage records remain in the executable but are no longer discoverable by `llvm-cov`, resulting in function/profile mismatch warnings and incomplete reports.

This fixes section-name decoding rather than changing COMDAT selection, coverage instrumentation, or executable code generation. The change also applies to other long section names using this encoding.

## Validation
- New regression crashes with the previous decoder and passes with the fix.
- Clean `dev`-based release build of radlink and torture; both COFF tests pass.
- Native two-translation-unit coverage fixture with Base64 section-name references beyond 10 MB: link, run, profile merge, and coverage report succeed without warnings.
- Combined downstream build: 15 targeted COFF/COMDAT tests pass, including the existing function-prefix regression; Oodle-compressed extended-name fixture passes end-to-end.
- Replayed a large x64 coverage target against the same existing profile: **635 mismatches before, zero after**. Both HTML and text `llvm-cov show` commands succeed with empty stderr. Coverage function/region/line/branch totals match lld-link.

Based directly on `dev`; no dependency on the other open radlink PRs.
